### PR TITLE
Feature/#12 build.gradle 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,15 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## Why need this change? 
- Redis, jwt 사용을 위해 의존성 추가

## Changes ✏️
- implementation 'org.springframework.boot:spring-boot-starter-data-redis'
- implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
- implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
- implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'

## Test checklist✅ (optional)