### PR TITLE
Feature/#21 약관관리 관련 수정,설정

### DIFF
--- a/src/main/java/com/project/finalproject/company/dto/TermsDTO.java
+++ b/src/main/java/com/project/finalproject/company/dto/TermsDTO.java
@@ -1,0 +1,51 @@
+package com.project.finalproject.company.dto;
+
+import com.project.finalproject.company.entity.Terms;
+import com.project.finalproject.company.entity.enums.TermsStatus;
+import com.project.finalproject.company.entity.enums.TermsType;
+
+import lombok.*;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TermsDTO {
+
+    private Long id; //PK
+
+    @NotNull
+    private TermsType type; //약관 타입
+
+    @NotEmpty
+    private String version; //약관 버전
+
+    private LocalDateTime createDate, editDate; //약관 생성일, 수정일
+
+    @NotEmpty
+    private String title; //약관 제목
+
+    @NotEmpty
+    private String contents; //약관 내용
+
+    @NotEmpty
+    private String name;// 작성자(기업명)
+
+    @NotNull
+    private TermsStatus termsStatus;    //약관 상태
+
+    public TermsDTO(Terms terms) {
+        this.id = terms.getId();
+        this.type = TermsType.valueOf(terms.getType().getTypes());
+        this.version = terms.getVersion();
+        this.createDate = terms.getCreateDate();
+        this.editDate = terms.getEditDate();
+        this.title = terms.getTitle();
+        this.contents = terms.getContents();
+        this.name = terms.getCompany().getName();
+        this.termsStatus = TermsStatus.valueOf(terms.getTermsStatus().getStatus());
+    }
+}

--- a/src/main/java/com/project/finalproject/company/entity/Company.java
+++ b/src/main/java/com/project/finalproject/company/entity/Company.java
@@ -1,12 +1,14 @@
 package com.project.finalproject.company.entity;
 
 import com.project.finalproject.company.entity.enums.CompanyType;
+import lombok.Getter;
 
 import javax.persistence.*;
 
 //기업 회원
 @Entity
 @Table(name = "tb_company")
+@Getter
 public class Company {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,6 +40,7 @@ public class Company {
     private String url; //회사 홈페이지
 
     @Column(name = "company_type")
+    @Enumerated(EnumType.STRING)
     private CompanyType companyType; // 기업 회원 타입 (기업/어드민)
 
 

--- a/src/main/java/com/project/finalproject/company/entity/Terms.java
+++ b/src/main/java/com/project/finalproject/company/entity/Terms.java
@@ -1,13 +1,26 @@
 package com.project.finalproject.company.entity;
 
+import com.project.finalproject.company.entity.enums.TermsStatus;
 import com.project.finalproject.company.entity.enums.TermsType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 //기업 약관
 @Entity
+@Builder
 @Table(name = "terms")
+@Getter
+@EntityListeners(value = {AuditingEntityListener.class})
+@NoArgsConstructor
+@AllArgsConstructor
 public class Terms {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,22 +28,29 @@ public class Terms {
     private Long id; //PK
 
     @Column(name = "terms_type")
-    private TermsType type; //약관 타입?
+    @Enumerated(EnumType.STRING)
+    private TermsType type; //약관 타입
 
     @Column(name = "terms_version")
     private String version; //약관 버전
 
-    @Column(name = "terms_create_date")
-    private LocalDate createDate; //약관 생성 날짜
+    @CreatedDate
+    @Column(name = "terms_create_date",updatable = false)
+    private LocalDateTime createDate; //약관 생성 날짜
 
+    @LastModifiedDate
     @Column(name = "terms_edit_date")
-    private LocalDate editDate; //약관 수정 날짜
+    private LocalDateTime editDate; //약관 수정 날짜
 
     @Column(name = "terms_title")
     private String title; //약관 제목
 
     @Column(name = "terms_contents", columnDefinition = "TEXT")
     private String contents; //약관 내용
+
+    @Column(name = "terms_status")
+    @Enumerated(EnumType.STRING)
+    private TermsStatus termsStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_serial_number")

--- a/src/main/java/com/project/finalproject/company/entity/enums/TermsStatus.java
+++ b/src/main/java/com/project/finalproject/company/entity/enums/TermsStatus.java
@@ -1,4 +1,16 @@
 package com.project.finalproject.company.entity.enums;
 
 public enum TermsStatus {
+
+    USE("사용"), TEMPORARY("임시저장"), DISCARD("폐기");
+
+    private String status;
+
+    TermsStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
 }

--- a/src/main/java/com/project/finalproject/company/entity/enums/TermsType.java
+++ b/src/main/java/com/project/finalproject/company/entity/enums/TermsType.java
@@ -1,5 +1,15 @@
 package com.project.finalproject.company.entity.enums;
 
 public enum TermsType {
+    SERVICE("서비스이용약관"), PRIVACY("개인정보처리방침"), THIRD_PARTY("제3자정보제공"), MARKETING("개인정보마케팅이용");
 
+    private String types;
+
+    TermsType(String types) {
+        this.types = types;
+    }
+
+    public String getTypes() {
+        return types;
+    }
 }

--- a/src/main/java/com/project/finalproject/company/repository/TermsRepository.java
+++ b/src/main/java/com/project/finalproject/company/repository/TermsRepository.java
@@ -1,0 +1,7 @@
+package com.project.finalproject.company.repository;
+
+import com.project.finalproject.company.entity.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermsRepository extends JpaRepository<Terms,Long> {
+}

--- a/src/main/java/com/project/finalproject/company/service/TermsService.java
+++ b/src/main/java/com/project/finalproject/company/service/TermsService.java
@@ -1,0 +1,8 @@
+package com.project.finalproject.company.service;
+
+import com.project.finalproject.company.dto.TermsDTO;
+
+public interface TermsService {
+
+    Long register(TermsDTO termsDTO);
+}


### PR DESCRIPTION
## Why need this change? 
- 약관 관리를 위한 기본설정

## Changes ✏️
- 1f5692204600d0932435396d2683742311945ed8 : Terms에 연관되는 데이터를 가져오기 위해 @Getter 설정
- 9449eb47ab4f434c7799bb7aeb999e9907f39b58 :  등록일과 수정일이 자동생성 되도록 설정변경, TermsStatus(상태)가 필요하여 추가
- 61bce9e1a02183768976421d1c7146aeb5fd3bdf : 엔티티는 가능하면 불변하게 하고 변경이 가능한 DTO 생성
- d37939b648548a025f356a6c6ecb21796782ceef : repository setting
- 5c2f70b3c6f1b2c28de605fa3cbd8b9c6765f731 : service setting, 등록관련 임시 기능 구현
- 99f4e4a229946ea13742de9b47c6357b2773c65b : TermsStatus(상태) 지정값으로 선택하기 위해 enum 값으로 설정
- 6f4175b15f5e6371ec251274088591f610010d66 : TermsType(종류) 지정값으로만 선택하기 위해 enum 값으로 설정

## Test checklist✅ (optional)
- 테스트 파일로 테스트 진행
![image](https://user-images.githubusercontent.com/109578096/227555158-9d550a7a-e230-454d-8160-24ae5ff00d5d.png)

