### PR TITLE
Feature/#22 슈퍼관리자 약관 목록조회, 상세조회

### DIFF
--- a/src/main/java/com/project/finalproject/term/entity/Term.java
+++ b/src/main/java/com/project/finalproject/term/entity/Term.java
@@ -1,10 +1,13 @@
 package com.project.finalproject.term.entity;
 
 import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.term.dto.TermResDTO;
 import com.project.finalproject.term.entity.enums.TermStatus;
 import com.project.finalproject.term.entity.enums.TermType;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -13,10 +16,18 @@ import java.time.LocalDateTime;
  * 약관
  */
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@ToString
+@EntityListeners(value = {AuditingEntityListener.class})
 @Table(name = "tb_term")
 public class Term {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "term_id")
     private Long id; //PK
 
@@ -46,4 +57,19 @@ public class Term {
     @JoinColumn(name = "company_id")
     private Company company;
 
+    public void setCompany(Company company) {
+        this.company = company;
+    }
+
+    public static Term createTerm(TermResDTO termResDTO, Company company) {
+        Term term = Term.builder()
+                .content(termResDTO.getContent())
+                .type(termResDTO.getType())
+                .version(termResDTO.getVersion())
+                .status(termResDTO.getStatus())
+                .company(company)
+                .build();
+
+        return term;
+    }
 }

--- a/src/main/java/com/project/finalproject/term/exception/TermExceptionType.java
+++ b/src/main/java/com/project/finalproject/term/exception/TermExceptionType.java
@@ -1,0 +1,26 @@
+package com.project.finalproject.term.exception;
+
+import com.project.finalproject.global.exception.base.CustomExceptionType;
+
+public enum TermExceptionType implements CustomExceptionType {
+
+    NOT_FOUND_PAGE(-301, "없는 게시글 입니다.");
+
+    private int errorCode;
+    private String errorMsg;
+
+    TermExceptionType(int errorCode, String errorMsg){
+        this.errorMsg = errorMsg;
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.errorMsg;
+    }
+
+    @Override
+    public int getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/test/java/com/project/finalproject/term/controller/TermController.java
+++ b/src/test/java/com/project/finalproject/term/controller/TermController.java
@@ -1,0 +1,57 @@
+package com.project.finalproject.term.controller;
+
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.term.dto.TermResDTO;
+import com.project.finalproject.term.service.TermService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TermController {
+
+    private final TermService termService;
+
+    /**
+     * 약관등록
+     */
+    @PostMapping(value = "/admin/term",consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseDTO<?> register(@Valid @RequestBody TermResDTO termResDTO) {
+        //Todo token생성 후 약관등록 파라미터 수정하기
+        String admin = "admin@admin.com";
+        Long termId =termService.register(termResDTO,admin);
+
+        if (termId == null) {
+            return new ResponseDTO<>().ok("유요하지않은 Id입니다");
+        }else {
+            return new ResponseDTO<>().ok(termId, "생성완료된 약관Id");
+        }
+    }
+
+    /**
+     * 약관목록조회
+     */
+    @GetMapping(value = "/admin/term/list")
+    public ResponseDTO<?> showTermList(){
+        //TODO : 토큰 완성되면 약관목록조회 파라미터 수정하기
+        String admin = "admin@admin.com";
+
+        List<TermResDTO.TermList> termList = termService.showTermList(admin);
+
+        return new ResponseDTO<>().ok(termList,"termList success");
+    }
+
+    @GetMapping("/admin/term/{termId}")
+    public ResponseDTO<?> showTermDetail(@PathVariable Long termId){
+        //TODO : 토큰 완성되면 약관상세조회 파라미터 수정하기
+        String admin = "admin@admin.com";
+
+        TermResDTO.TermDetail termDetail = termService.showTermDetail(admin, termId);
+
+        return new ResponseDTO<>().ok(termDetail,"termDetail success");
+    }
+}

--- a/src/test/java/com/project/finalproject/term/dto/TermResDTO.java
+++ b/src/test/java/com/project/finalproject/term/dto/TermResDTO.java
@@ -1,0 +1,72 @@
+package com.project.finalproject.term.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.finalproject.term.entity.Term;
+import com.project.finalproject.term.entity.enums.TermStatus;
+import com.project.finalproject.term.entity.enums.TermType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TermResDTO {
+    private Long id;
+    private String content;
+
+    private TermType type;
+    private String version;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createDate;
+    private LocalDateTime editDate;
+
+    private TermStatus status;
+
+    // 약관 전체목록 조회
+    @Getter
+    public static class TermList {
+        private Long termId;    // 약관id
+        private String type;  // 약관종류
+        private String version; // 버전
+        private LocalDateTime creatDate;    // 등록일
+        private LocalDateTime editDate; // 수정일
+        private String status;  // 약관상태
+
+        @Builder
+        public TermList(Term term) {
+            this.termId = term.getId();
+            this.type = term.getType().getType();
+            this.version = term.getVersion();
+            this.creatDate = term.getCreateDate();
+            this.editDate = term.getEditDate();
+            this.status = term.getStatus().getStatus();
+        }
+    }
+
+    // 약관 상세조회
+    @Getter
+    public static class TermDetail {
+        private Long termId;    // 약관id
+        private String content; // 내용
+        private String type;  // 약관종류
+        private String version; // 버전
+        private LocalDateTime createDate;   //생성일
+        private LocalDateTime editDate; // 수정일
+        private String status;  // 약관상태
+
+        @Builder
+        public TermDetail(Term term) {
+            this.termId = term.getId();
+            this.content = term.getContent();
+            this.type = term.getType().getType();
+            this.version = term.getVersion();
+            this.createDate = term.getCreateDate();
+            this.editDate = term.getEditDate();
+            this.status = term.getStatus().getStatus();
+        }
+    }
+}

--- a/src/test/java/com/project/finalproject/term/exception/TermException.java
+++ b/src/test/java/com/project/finalproject/term/exception/TermException.java
@@ -1,0 +1,18 @@
+package com.project.finalproject.term.exception;
+
+import com.project.finalproject.global.exception.base.CustomException;
+import com.project.finalproject.global.exception.base.CustomExceptionType;
+
+public class TermException extends CustomException {
+
+    private TermExceptionType termExceptionType;
+
+    public TermException(TermExceptionType termExceptionType){
+        this.termExceptionType = termExceptionType;
+    }
+
+    @Override
+    public CustomExceptionType getExceptionType() {
+        return this.termExceptionType;
+    }
+}

--- a/src/test/java/com/project/finalproject/term/repository/TermRepository.java
+++ b/src/test/java/com/project/finalproject/term/repository/TermRepository.java
@@ -1,0 +1,14 @@
+package com.project.finalproject.term.repository;
+
+import com.project.finalproject.term.entity.Term;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+
+    @Query("SELECT t FROM Term t WHERE t.company.id = :companyId")
+    List<Term> findByCompanyId(@Param("companyId") Long companyId);
+}

--- a/src/test/java/com/project/finalproject/term/service/TermService.java
+++ b/src/test/java/com/project/finalproject/term/service/TermService.java
@@ -1,0 +1,19 @@
+package com.project.finalproject.term.service;
+
+import com.project.finalproject.term.dto.TermResDTO;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Transactional
+public interface TermService {
+
+    // 약관등록
+    Long register(TermResDTO termResDTO, String adminEmail);
+
+    // 약관 전체목록 조회
+    List<TermResDTO.TermList> showTermList(String adminEmail);
+
+    // 약관 상세조회
+    TermResDTO.TermDetail showTermDetail(String adminEmail, Long termId);
+}

--- a/src/test/java/com/project/finalproject/term/service/TermServiceImpl.java
+++ b/src/test/java/com/project/finalproject/term/service/TermServiceImpl.java
@@ -1,0 +1,87 @@
+package com.project.finalproject.term.service;
+
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.company.exception.CompanyException;
+import com.project.finalproject.company.exception.CompanyExceptionType;
+import com.project.finalproject.company.repository.CompanyRepository;
+import com.project.finalproject.term.dto.TermResDTO;
+import com.project.finalproject.term.entity.Term;
+import com.project.finalproject.term.exception.TermException;
+import com.project.finalproject.term.exception.TermExceptionType;
+import com.project.finalproject.term.repository.TermRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermServiceImpl implements TermService {
+
+    private final TermRepository termRepository;
+    private final CompanyRepository companyRepository;
+
+    /**
+     * 슈퍼관리자(admin) 약관 등록
+     * @param termResDTO
+     * @param adminEmail
+     * @return termId
+     */
+    @Override
+    public Long register(TermResDTO termResDTO, String adminEmail) {
+
+        Optional<Company> company = companyRepository.findByEmail(adminEmail);
+
+        if (company.isEmpty()) {
+            return null;
+        } else {
+            Term term = Term.createTerm(termResDTO,company.get());
+            termRepository.save(term);
+
+            return term.getId();
+        }
+    }
+
+    /**
+     * 슈퍼관리자(admin) 약관 전체목록 조회
+     * @param adminEmail
+     * @return 약관 목록 조회
+     */
+    @Override
+    public List<TermResDTO.TermList> showTermList(String adminEmail) {
+
+        Company company = companyRepository.findByEmail(adminEmail).orElseThrow(
+                () -> new CompanyException(CompanyExceptionType.NOT_FOUND_USER)
+        );
+
+        List<Term> terms = termRepository.findByCompanyId(company.getId());
+
+        return terms.stream()
+                .map(TermResDTO.TermList::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 슈퍼관리자(admin) 약관 상세조회
+     * @param adminEmail
+     * @param termId
+     * @return 약관 상세조회
+     */
+    @Override
+    public TermResDTO.TermDetail showTermDetail(String adminEmail, Long termId) {
+        Company company = companyRepository.findByEmail(adminEmail).orElseThrow(
+                () -> new CompanyException(CompanyExceptionType.NOT_FOUND_USER)
+        );
+
+
+        Term term = termRepository.findById(termId).orElseThrow(
+                () -> new TermException(TermExceptionType.NOT_FOUND_PAGE)
+        );
+
+        return TermResDTO.TermDetail.builder()
+                .term(term)
+                .build();
+    }
+}


### PR DESCRIPTION
## Why need this change? 
- 슈퍼관리자 약관 목록조회, 상세조회

## Changes ✏️
- f546af07c01b30bbc7c0876efe6e88a6ff352f1c : dto이름변경, 조회에 필요한 dto값 설정
- edb2fc63cc3f3e57ee1cfab836fe999747d0104a : 엔티티에 company값 set설정, createTerm메소드추가
- 5b5ae4e6bb4a98f38a15dd00baeeeea49dd5888e : companyId 값으로 검색하도록 repo설정
- 1bfc40720d168c8ec1b88bf6775e407957e61da3 : 목록조회,상세조회 service 설정
- a779cd5b89bfc0206908acecf8765f8baa055efa : 목록조회,상세조회 serviceimpl 설정
- d45d852ba89e107df88ed0b99c51333d9ebbf67c : 예외타입값 설정
- 57606304d50e76c6f60fd567001f844cf7e0a610 : 예외 설정
- 91f3ac00349646a3e0ad209cf6c28fe649b3e868 : 목록조회, 상세조회 controller 설정

## Test checklist✅ (optional)
- token 값 이후 적용할 예정
![image](https://user-images.githubusercontent.com/109578096/229445921-5ac29d0d-510f-4c6f-b3fb-b9b1fe904155.png)
![image](https://user-images.githubusercontent.com/109578096/229445943-d2ac207c-d75b-47a8-af5d-53e4dd01191f.png)
