### PR TITLE
Feat/#52 토큰의 유효성 검사 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,28 +19,36 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    // jdbc
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    // spring boot
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    //lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    //lombok test
+    testCompileOnly 'org.projectlombok:lombok:1.18.24'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    //mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-
-
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
@@ -1,10 +1,13 @@
 package com.project.finalproject.global.config;
 
+import com.project.finalproject.global.jwt.utils.JwtExceptionFilter;
 import com.project.finalproject.global.jwt.utils.JwtFilter;
 import com.project.finalproject.global.jwt.utils.JwtProperties;
 import com.project.finalproject.global.jwt.utils.JwtUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,14 +19,21 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class SecurityConfig {
 
-    // jwt 토큰을 사용하지 않는 URL
+    /**
+     * 토큰을 사용하지 않는 허용 url
+     */
     String[] permitUrl = {"/**",
             "/company/login","/applicant/signup","applicant/checkemail",
             "/applicant/login","/company/signup", "/refresh","/admin/term/**"};
+
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+    private final StringRedisTemplate stringRedisTemplate;
 
 
     @Bean
@@ -36,15 +46,19 @@ public class SecurityConfig {
                 .formLogin().disable() //formLogin 인증 비활성화
                 .httpBasic().disable() //httpBasic 인증 비활성화
                 .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        http    .authorizeRequests()
+                .mvcMatchers(permitUrl)
+                .permitAll()
                 .and()
                 .authorizeRequests()
-                .antMatchers(permitUrl)
-                .permitAll()
                 .anyRequest().authenticated();
 
+
         http
-                .addFilterBefore(new JwtFilter(new JwtUtil(new JwtProperties())), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(JwtFilter.of(jwtUtil, jwtProperties, stringRedisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(JwtExceptionFilter.of(jwtUtil, jwtProperties), JwtFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/project/finalproject/global/exception/UtilException.java
+++ b/src/main/java/com/project/finalproject/global/exception/UtilException.java
@@ -1,0 +1,16 @@
+package com.project.finalproject.global.exception;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UtilException extends RuntimeException {
+
+    private Integer errorCode;// = 0;
+    private HttpStatus httpStatus;// = HttpStatus.FORBIDDEN;
+    private String errorMsg;// = null;
+}

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtExceptionFilter.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtExceptionFilter.java
@@ -1,0 +1,72 @@
+package com.project.finalproject.global.jwt.utils;
+
+import com.project.finalproject.global.exception.UtilException;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@Getter
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private static JwtUtil jwtutil;
+
+    @Autowired
+    private final JwtProperties jwtProperties;
+    public JwtExceptionFilter(JwtUtil jwtutil, JwtProperties jwtProperties) {
+        this.jwtutil = jwtutil;
+        this.jwtProperties = jwtProperties;
+    }
+
+    public static JwtExceptionFilter of(JwtUtil jwtUtil, JwtProperties jwtProperties){
+        return new JwtExceptionFilter(jwtutil, jwtProperties);
+    }
+
+    /**
+     * Jwtfilter보다 먼저 실행하고, Jwtfilter에서 예외 발생하면 여기서 처리
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (UtilException e) {
+            setErrorResponse(response, e);
+        }
+    }
+
+    /**
+     * 예외를 종류별로 처리하는 메서드
+     */
+    public void setErrorResponse(HttpServletResponse response, UtilException utilException) throws IOException {
+        response.setStatus(utilException.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        if(utilException.getErrorMsg().equals("REFRESH") || utilException.getErrorMsg().equals("INVALID")){
+            response.getWriter().println("{ \"stateCode\" : " + utilException.getErrorCode()
+                    + ", \"success\" : \"" + "false"
+                    + "\", \"message\" : \"" + utilException.getErrorMsg()
+                    + "\", \"data\" : \"" + null
+                    + "\" }");
+        }
+        else {
+            String refreshToken = utilException.getErrorMsg();
+            String email = jwtutil.getRefreshUserEmail(refreshToken);
+            String role = jwtutil.getRole(refreshToken);
+            String accessToken = jwtutil.createAccessToken(email, jwtProperties.getSecretKey(), role);
+            response.getWriter().println("{ \"stateCode\" : " + utilException.getErrorCode()
+                    + ", \"success\" : \"" + "false"
+                    + "\", \"message\" : \"" + "새로운 AccessToken입니다."
+                    + "\", \"data\" : \"" + accessToken
+                    + "\" }");
+        }
+    }
+
+}

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtFilter.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtFilter.java
@@ -1,12 +1,12 @@
 package com.project.finalproject.global.jwt.utils;
 
+import com.project.finalproject.global.exception.*;
 import com.project.finalproject.login.dto.LoginResDTO;
-import io.jsonwebtoken.ExpiredJwtException;
-import lombok.Builder;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -17,50 +17,128 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Set;
+import java.util.HashMap;
 
 @Component
 @Getter
 public class JwtFilter extends OncePerRequestFilter {
 
+    /**
+     * 허용할 url 세팅
+     */
+    private HashMap<String, String> permitUrl = new HashMap<>(){{
+        put("/company/login","permit");
+        put("/applicant/login","permit");
+        put("/company/signup","permit");
+        put("/applicant/signup","permit");
+        put("/refresh","permit");
+        put("/admin/login","permit");
+    }};
+
     @Autowired
     private final JwtUtil jwtUtil;
+    @Autowired
+    private final JwtProperties jwtProperties;
+    @Autowired
+    private final StringRedisTemplate stringRedisTemplate;
 
     @Autowired
-    private StringRedisTemplate stringRedisTemplate;
-
-    @Autowired
-    @Builder
-    public JwtFilter(JwtUtil jwtUtil) {
+    public JwtFilter(JwtUtil jwtUtil, JwtProperties jwtProperties, StringRedisTemplate stringRedisTemplate) {
         this.jwtUtil = jwtUtil;
+        this.jwtProperties = jwtProperties;
+        this.stringRedisTemplate = stringRedisTemplate;
     }
 
-    public static JwtFilter of(JwtUtil jwtUtil){
-        return new JwtFilter(jwtUtil);
+    public static JwtFilter of(JwtUtil jwtUtil,JwtProperties jwtProperties, StringRedisTemplate stringRedisTemplate) {
+        return new JwtFilter(jwtUtil,jwtProperties,stringRedisTemplate);
     }
-
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-        if(authorizationHeader == null || !authorizationHeader.startsWith("Bearer")){
-            filterChain.doFilter(request, response);
-            return;
+        String uri = request.getRequestURI();
+        /**
+         * Authorization 헤더값이 유효한지 검증
+         */
+        if(jwtUtil.checkHeader(authorizationHeader)){
+            if(permitUrl.containsKey(uri)){
+                filterChain.doFilter(request, response);
+                return;
+            }
+            throw new UtilException(403, HttpStatus.FORBIDDEN, "INVALID");
         }
+        String accessToken = jwtUtil.extractToken(authorizationHeader);
 
-        if(!stringRedisTemplate.hasKey(jwtUtil.extractToken(authorizationHeader))){
-            try{
-                LoginResDTO user = jwtUtil.getResDTO(authorizationHeader);
-                SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(user,
-                        "",
-                        user.getAuthorities()));
-            } catch (ExpiredJwtException e){
-                logger.error("ExpiredJwtException : Token has been expired");
-            } catch (Exception e){
-                logger.error("Exception : There is no token");
+        /**
+         * AccessToken이 블랙리스트(Redis)에 있는지 확인
+         */
+        if(stringRedisTemplate.hasKey(accessToken)){
+            //login페이지로 redirect하라는 response
+            if(jwtUtil.getRole(accessToken).equals("USER")){
+                response.sendRedirect("/applicant/login");
+                filterChain.doFilter(request, response);
+                return;
+            }
+            else if(jwtUtil.getRole(accessToken).equals("COMPANY")){
+                response.sendRedirect("/company/login");
+                filterChain.doFilter(request, response);
+                return;
+            }
+            else {
+                response.sendRedirect("/admin/login");
+                filterChain.doFilter(request, response);
+                return;
             }
         }
+
+
+        /**
+         * AccessToken 기간이 유효한지 확인
+         */
+        if(jwtUtil.isAccessExpired(accessToken, jwtProperties.getSecretKey())){
+            /**
+             * AccessToken 유효하지 않을때, Refresh헤더를 확인
+             */
+            String refreshHeader = request.getHeader("REFRESH");
+            if(jwtUtil.checkHeader(refreshHeader)){
+                if(permitUrl.containsKey(request.getRequestURI())){
+                    filterChain.doFilter(request,response);
+                    return;
+                }
+                throw new UtilException(403, HttpStatus.FORBIDDEN, "REFRESH");
+            }
+            String refreshToken = jwtUtil.extractToken(refreshHeader);
+            /**
+             * AccessToken 유효하지 않고, Refresh 토큰을 받았을 때
+             */
+            if(jwtUtil.isRefreshExpired(refreshToken, jwtProperties.getSecretKey())){
+                //login페이지로 redirect 하라는 response
+                if(jwtUtil.getRole(refreshToken).equals("USER")){
+                    response.sendRedirect("/applicant/login");
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+                else if(jwtUtil.getRole(refreshToken).equals("COMPANY")){
+                    response.sendRedirect("/company/login");
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+                else {
+                    response.sendRedirect("/admin/login");
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+            }
+            else{
+                //새로운 accesstoken 발급하는 예외처리
+                throw new UtilException(403, HttpStatus.FORBIDDEN, refreshToken);
+            }
+        }
+        LoginResDTO user = jwtUtil.getResDTO(authorizationHeader);
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(user,
+                "",
+                user.getAuthorities()));
+
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtProperties.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtProperties.java
@@ -1,8 +1,6 @@
 package com.project.finalproject.global.jwt.utils;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConstructorBinding;
@@ -11,8 +9,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConstructorBinding
 @Getter
-@RequiredArgsConstructor
 @ToString
+@NoArgsConstructor
+@AllArgsConstructor
 public class JwtProperties {
 
     @Value("${jwt.issuer}")

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
@@ -7,27 +7,26 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
-
 import java.time.Duration;
 import java.util.Date;
 
 @Component
+@RequiredArgsConstructor
 public class JwtUtil {
 
     private final JwtProperties jwtProperties;
     Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public JwtUtil(JwtProperties jwtProperties) {
-        this.jwtProperties = jwtProperties;
-    }
+//    public JwtUtil(JwtProperties jwtProperties) {
+//        this.jwtProperties = jwtProperties;
+//    }
 
     /**
      * 헤더로부터 LoginResDTO 생성
      */
     public LoginResDTO getResDTO(String authorizationHeader) {
-        checkAuthorizationHeader(authorizationHeader);
+        checkHeader(authorizationHeader);
         String token = "";
         Claims claims = null;
         try {
@@ -43,11 +42,12 @@ public class JwtUtil {
     /**
      * 헤더값이 유효한지 검증
      */
-    private boolean checkAuthorizationHeader(String header) {
+    boolean checkHeader(String header) {
         if (header == null || !header.startsWith(jwtProperties.getTokenPrefix())) {
-            logger.error("토큰이 없습니다.(1)");
+            logger.error("없는 토큰 또는 잘못된 형식의 토큰입니다.");
+            return true;
         }
-        return true;
+        return false;
     }
 
     /**
@@ -76,11 +76,25 @@ public class JwtUtil {
     }
 
     /**
+     * 토큰에서 role 추출
+     */
+    public String getRole(String token) {
+        return Jwts.parser().setSigningKey(jwtProperties.getSecretKey()).parseClaimsJws(token)
+                .getBody().get("role", String.class);
+    }
+
+    /**
      * Access 토큰 만료 확인
      */
     public static boolean isAccessExpired(String token, String secretKey) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
-                .getBody().getExpiration().before(new Date());
+        try{
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                    .getBody().getExpiration().before(new Date());
+            return false;
+        }
+        catch(Exception e){
+            return true;
+        }
     }
 
     /**
@@ -95,7 +109,7 @@ public class JwtUtil {
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + Duration.ofMinutes(5).toMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + Duration.ofMinutes(1).toMillis())) //테스트를 위해 1분으로 해놓음. 원랜 5분
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
@@ -112,8 +126,14 @@ public class JwtUtil {
      * Refresh 토큰 만료 확인
      */
     public static boolean isRefreshExpired(String token, String secretKey) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
-                .getBody().getExpiration().before(new Date());
+        try{
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                    .getBody().getExpiration().before(new Date());
+            return false;
+        }
+        catch(Exception e){
+            return true;
+        }
     }
 
     /**

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.util.Date;
+import java.util.HashMap;
 
 @Component
 @RequiredArgsConstructor
@@ -18,9 +19,6 @@ public class JwtUtil {
     private final JwtProperties jwtProperties;
     Logger logger = LoggerFactory.getLogger(this.getClass());
 
-//    public JwtUtil(JwtProperties jwtProperties) {
-//        this.jwtProperties = jwtProperties;
-//    }
 
     /**
      * 헤더로부터 LoginResDTO 생성
@@ -152,4 +150,20 @@ public class JwtUtil {
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
+
+    /**
+     * 헤더에서 토큰을 추출하고 토큰으로 부터 Email, role을 추출해주는 메서드
+     */
+    public HashMap<String, String> allInOne(String authorizationHeader){
+        HashMap<String, String> info = new HashMap<>();
+        String token = authorizationHeader.substring(jwtProperties.getTokenPrefix().length());
+        String email = getAccessUserEmail(token);
+        String role = getRole(token);
+
+        info.put(email,"email");
+        info.put(role, "role");
+
+        return info;
+    }
+
 }

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
 //@TestPropertySource(locations = "classpath:application-local.properties")
-@TestPropertySource(locations = "classpath:application.properties")
+@TestPropertySource(locations = "classpath:application-test.properties")
 public class 내_정보 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보.java
@@ -31,7 +31,8 @@ import static org.mockito.Mockito.when;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 내_정보 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보수정.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보수정.java
@@ -30,7 +30,8 @@ import static org.mockito.Mockito.when;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 내_정보수정 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보수정.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/내_정보수정.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
 //@TestPropertySource(locations = "classpath:application-local.properties")
-@TestPropertySource(locations = "classpath:application.properties")
+@TestPropertySource(locations = "classpath:application-test.properties")
 public class 내_정보수정 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/이력서_등록.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/이력서_등록.java
@@ -40,7 +40,8 @@ import static org.mockito.Mockito.*;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 이력서_등록 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/이력서_삭제.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/이력서_삭제.java
@@ -40,7 +40,8 @@ import static org.mockito.Mockito.*;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 이력서_삭제 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/이력서_조회.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/이력서_조회.java
@@ -41,7 +41,8 @@ import org.springframework.core.io.Resource;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 이력서_조회 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/이메일_중복체크.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/이메일_중복체크.java
@@ -24,7 +24,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 이메일_중복체크 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/지원취소.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/지원취소.java
@@ -37,7 +37,8 @@ import static org.mockito.Mockito.*;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 지원취소 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/지원하기.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/지원하기.java
@@ -44,7 +44,8 @@ import static org.mockito.Mockito.*;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 지원하기 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/지원한_채용공고.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/지원한_채용공고.java
@@ -32,7 +32,8 @@ import static org.mockito.Mockito.when;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 지원한_채용공고 {
 
 

--- a/src/test/java/com/project/finalproject/applicant/service/Impl/회원가입.java
+++ b/src/test/java/com/project/finalproject/applicant/service/Impl/회원가입.java
@@ -23,7 +23,8 @@ import static org.mockito.Mockito.when;
 @AutoConfigureMockMvc(addFilters = false) //SecurityConfig를 무시하고 테스트
 @SpringBootTest
 @Import(ApplicantServiceImpl.class)
-@TestPropertySource(locations = "classpath:application-local.properties")
+//@TestPropertySource(locations = "classpath:application-local.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 public class 회원가입 {
 
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,11 @@
+
+#test db
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWD}
+
+#redis
+spring.redis.host=${REDIS_HOST}
+spring.redis.port=${REDIS_PORT}
+spring.redis.password=${REDIS_PASSWD}


### PR DESCRIPTION
## Why need this change? 
- 파일 수정 및 기능 구현

## Changes ✏️
- e64a2b5 JwtFilter 수정 및 JwtExceptionFilter 생성
- 83fc84e JwtFilter 수정(feat:토큰의 유효성 검사 및 재발급 기능 구현 ->이걸로 커밋 메세지 바꿨는데 반영이 안되어있네요;)
- ea7c709 JwtUtil 수정
- 3b82fbc 예외처리 클래스 UtilException 생성
- 514de28 Security Config 수정
- 2b4ce20 Rebase 후 Thomas Choi 요청으로 인한 JwtUtil 메서드 추가

## Test checklist✅ (optional)
-  정상적인 AccessToken일 때
![정상ac토큰](https://user-images.githubusercontent.com/113500922/229726472-10e19610-7896-4c5a-985e-c19d83d3cd20.png)

- AccessToken이 만료되어 Refresh헤더를 요청하는 response
![at만료rt요청](https://user-images.githubusercontent.com/113500922/229726568-0b3857f1-8129-47b3-a216-d981840c322e.png)

- AccessToken이 만료되었고, RefreshToken이 정상일때 새로운 AccessToken을 발급
![at만료rt재발급](https://user-images.githubusercontent.com/113500922/229726648-9e2a1434-b5ad-4abd-836b-7b25cf7279a4.png)
