### PR TITLE
Feat/#17 지원자/기업/관리자 로그인 기능 구현 및 기타 수정

### DIFF
--- a/src/main/java/com/project/finalproject/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/project/finalproject/applicant/controller/ApplicantController.java
@@ -28,12 +28,6 @@ public class ApplicantController {
         return new ResponseDTO(200, true, null, "테스트");
     }
 
-    // 로그인
-    @PostMapping("/login")
-    public ResponseDTO login(){
-        return new ResponseDTO(200, true, null, "로그인 성공");
-    }
-
     @PostMapping("/checkemail")
     public ResponseDTO checkEmail(@RequestBody SignupRequestDTO signupRequestDTO){
         if(applicantService.checkEmail(signupRequestDTO).equals("duplicate id")){

--- a/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
      */
     String[] permitUrl = {"/**",
             "/company/login","/applicant/signup","applicant/checkemail",
-            "/applicant/login","/company/signup", "/refresh","/admin/term/**"};
+            "/applicant/login","/company/signup", "/refresh","/admin/term/**","/admin/login"};
 
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtExceptionFilter.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtExceptionFilter.java
@@ -60,7 +60,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             String refreshToken = utilException.getErrorMsg();
             String email = jwtutil.getRefreshUserEmail(refreshToken);
             String role = jwtutil.getRole(refreshToken);
-            String accessToken = jwtutil.createAccessToken(email, jwtProperties.getSecretKey(), role);
+            Long id = jwtutil.getId(refreshToken);
+            String accessToken = jwtutil.createAccessToken(email, jwtProperties.getSecretKey(), role, id);
             response.getWriter().println("{ \"stateCode\" : " + utilException.getErrorCode()
                     + ", \"success\" : \"" + "false"
                     + "\", \"message\" : \"" + "새로운 AccessToken입니다."

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
@@ -98,10 +98,11 @@ public class JwtUtil {
     /**
      * Access 토큰 생성
      */
-    public String createAccessToken(String userEmail, String secretKey, String role) {
+    public String createAccessToken(String userEmail, String secretKey, String role, Long id) {
         Claims claims = Jwts.claims().setSubject(userEmail);
         claims.put("userEmail", userEmail);
         claims.put("role", role);
+        claims.put("id", id);
         claims.put("issuer", jwtProperties.getIssuer());
 
         return Jwts.builder()
@@ -137,10 +138,11 @@ public class JwtUtil {
     /**
      * Refresh 토큰 생성
      */
-    public String createRefreshToken(String userEmail, String secretKey, String role) {
+    public String createRefreshToken(String userEmail, String secretKey, String role, Long id) {
         Claims claims = Jwts.claims().setSubject(userEmail);
         claims.put("userEmail", userEmail);
         claims.put("role", role);
+        claims.put("id", id);
         claims.put("issuer", jwtProperties.getIssuer());
 
         return Jwts.builder()
@@ -164,6 +166,14 @@ public class JwtUtil {
         info.put(role, "role");
 
         return info;
+    }
+
+    /**
+     * 토큰에서 id값 추출
+     */
+    public Long getId(String token) {
+        return Jwts.parser().setSigningKey(jwtProperties.getSecretKey()).parseClaimsJws(token)
+                .getBody().get("id", Long.class);
     }
 
 }

--- a/src/main/java/com/project/finalproject/login/controller/ApplicantLoginController.java
+++ b/src/main/java/com/project/finalproject/login/controller/ApplicantLoginController.java
@@ -1,4 +1,26 @@
 package com.project.finalproject.login.controller;
 
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.login.dto.LoginReqDTO;
+import com.project.finalproject.login.dto.LoginResDTO;
+import com.project.finalproject.login.service.ApplicantLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class ApplicantLoginController {
+
+    private final ApplicantLoginService applicantLoginService;
+
+    @PostMapping("/applicant/login")
+    public ResponseDTO userLogin(@RequestBody LoginReqDTO req){
+
+        if(req.getEmail() == null || req.getPassword() == null){
+            return new ResponseDTO(401, false,"INVALID", "이메일이나 비밀번호가 틀렸습니다.");
+        }
+        return applicantLoginService.userLogin(req);
+    }
 }

--- a/src/main/java/com/project/finalproject/login/controller/CompanyLoginController.java
+++ b/src/main/java/com/project/finalproject/login/controller/CompanyLoginController.java
@@ -1,4 +1,33 @@
 package com.project.finalproject.login.controller;
 
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.login.dto.LoginReqDTO;
+import com.project.finalproject.login.dto.LoginResDTO;
+import com.project.finalproject.login.service.CompanyLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class CompanyLoginController {
+
+    private final CompanyLoginService companyLoginService;
+
+    @PostMapping("/company/login")
+    public ResponseDTO companyLogin(@RequestBody LoginReqDTO req){
+        if(req.getEmail() == null || req.getPassword() == null){
+            return new ResponseDTO(401, false, "INVALID","이메일이나 비밀번호가 틀렸습니다.");
+        }
+        return companyLoginService.companyLogin(req);
+    }
+
+    @PostMapping("/admin/login")
+    public ResponseDTO adminLogin(@RequestBody LoginReqDTO req){
+        if(req.getEmail() == null || req.getPassword() == null){
+            return new ResponseDTO(401, false, "INVALID","이메일이나 비밀번호가 틀렸습니다.");
+        }
+        return companyLoginService.adminLogin(req);
+    }
 }

--- a/src/main/java/com/project/finalproject/login/repository/ApplicantLoginRepository.java
+++ b/src/main/java/com/project/finalproject/login/repository/ApplicantLoginRepository.java
@@ -1,4 +1,12 @@
 package com.project.finalproject.login.repository;
 
-public interface ApplicantLoginRepository {
+import com.project.finalproject.applicant.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplicantLoginRepository extends JpaRepository<Applicant, Long> {
+
+    Optional<Applicant> findApplicantByEmail(String email);
+    Boolean existsApplicantByEmail(String email);
 }

--- a/src/main/java/com/project/finalproject/login/repository/CompanyLoginRepository.java
+++ b/src/main/java/com/project/finalproject/login/repository/CompanyLoginRepository.java
@@ -1,4 +1,13 @@
 package com.project.finalproject.login.repository;
 
-public interface CompanyLoginRepository {
+import com.project.finalproject.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CompanyLoginRepository extends JpaRepository<Company, Long> {
+
+    Optional<Company> findCompanyByEmail(String email);
+    Boolean existsCompanyByEmail(String email);
+
 }

--- a/src/main/java/com/project/finalproject/login/service/ApplicantLoginService.java
+++ b/src/main/java/com/project/finalproject/login/service/ApplicantLoginService.java
@@ -1,4 +1,58 @@
 package com.project.finalproject.login.service;
 
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.jwt.utils.JwtProperties;
+import com.project.finalproject.global.jwt.utils.JwtUtil;
+import com.project.finalproject.login.dto.LoginReqDTO;
+import com.project.finalproject.login.dto.LoginResDTO;
+import com.project.finalproject.login.repository.ApplicantLoginRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class ApplicantLoginService {
+
+    private final ApplicantLoginRepository applicantLoginRepository;
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 로그인
+     */
+    @Transactional(readOnly = true)
+    public ResponseDTO userLogin(LoginReqDTO req){
+        if(!applicantLoginRepository.existsApplicantByEmail(req.getEmail())){
+            return new ResponseDTO(401, false, "INVALID_ID", "잘못된 ID입니다.");
+        }
+
+        Applicant findUser = applicantLoginRepository.findApplicantByEmail(req.getEmail()).orElseThrow();
+
+        if(!checkPassword(req.getPassword(), findUser.getPassword())){
+            return new ResponseDTO(401, false, "INVALID_PASSWORD", "잘못된 비밀번호입니다.");
+        }
+
+        String accessToken = jwtUtil.createAccessToken(findUser.getEmail(), jwtProperties.getSecretKey(), "USER", findUser.getId());
+        String refreshToken = jwtUtil.createRefreshToken(findUser.getEmail(), jwtProperties.getSecretKey(), "USER", findUser.getId());
+
+        return new ResponseDTO(200, true, LoginResDTO.builder()
+                .email(findUser.getEmail())
+                .role("USER")
+                .name(findUser.getName())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build(), "로그인 성공!");
+    }
+
+    /**
+     * 비밀번호 일치여부 확인
+     */
+    private boolean checkPassword(String inputPassword, String originalPassword){
+        return passwordEncoder.matches(inputPassword, originalPassword);
+    }
 }

--- a/src/main/java/com/project/finalproject/login/service/CompanyLoginService.java
+++ b/src/main/java/com/project/finalproject/login/service/CompanyLoginService.java
@@ -1,4 +1,90 @@
 package com.project.finalproject.login.service;
 
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.jwt.utils.JwtProperties;
+import com.project.finalproject.global.jwt.utils.JwtUtil;
+import com.project.finalproject.login.dto.LoginReqDTO;
+import com.project.finalproject.login.dto.LoginResDTO;
+import com.project.finalproject.login.repository.CompanyLoginRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class CompanyLoginService {
+
+    private final CompanyLoginRepository companyLoginRepository;
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 기업회원 로그인
+     */
+    @Transactional(readOnly = true)
+    public ResponseDTO companyLogin(LoginReqDTO req){
+
+        if(!companyLoginRepository.existsCompanyByEmail(req.getEmail())){
+            return new ResponseDTO(401, false, "INVALID_ID", "잘못된 ID입니다.");
+        }
+
+        Company findCompany = companyLoginRepository.findCompanyByEmail(req.getEmail()).orElseThrow();
+
+
+        if(!checkPassword(req.getPassword(), findCompany.getPassword())){
+            return new ResponseDTO(401, false, "INVALID_PASSWORD", "잘못된 비밀번호입니다.");
+        }
+
+        String accessToken = jwtUtil.createAccessToken(findCompany.getEmail(), jwtProperties.getSecretKey(), "COMPANY", findCompany.getId());
+        String refreshToken = jwtUtil.createRefreshToken(findCompany.getEmail(), jwtProperties.getSecretKey(), "COMPANY", findCompany.getId());
+
+        return new ResponseDTO(200, true, LoginResDTO.builder()
+                .email(findCompany.getEmail())
+                .role("COMPANY")
+                .name(findCompany.getName())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build(), "로그인 성공!");
+    }
+
+    /**
+     * 관리자 로그인
+     */
+    @Transactional(readOnly = true)
+    public ResponseDTO adminLogin(LoginReqDTO req){
+
+        if(!companyLoginRepository.existsCompanyByEmail(req.getEmail())){
+            return new ResponseDTO(401, false, "INVALID_ID", "잘못된 ID입니다.");
+        }
+
+        Company findCompany = companyLoginRepository.findCompanyByEmail(req.getEmail()).orElseThrow();
+
+
+        if(!checkPassword(req.getPassword(), findCompany.getPassword())){
+            return new ResponseDTO(401, false, "INVALID_PASSWORD", "잘못된 비밀번호입니다.");
+        }
+
+        String accessToken = jwtUtil.createAccessToken(findCompany.getEmail(), jwtProperties.getSecretKey(), "ADMIN", findCompany.getId());
+        String refreshToken = jwtUtil.createRefreshToken(findCompany.getEmail(), jwtProperties.getSecretKey(), "ADMIN", findCompany.getId());
+
+        return new ResponseDTO(200, true, LoginResDTO.builder()
+                .email(findCompany.getEmail())
+                .role("ADMIN")
+                .name(findCompany.getName())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build(), "로그인 성공!");
+    }
+
+    /**
+     * 비밀번호 일치여부 확인
+     */
+    private boolean checkPassword(String inputPassword, String originalPassword){
+        return passwordEncoder.matches(inputPassword, originalPassword);
+    }
+
 }

--- a/src/main/java/com/project/finalproject/signup/controller/CompanySignupController.java
+++ b/src/main/java/com/project/finalproject/signup/controller/CompanySignupController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class SignupController {
+public class CompanySignupController {
     private final CompanySignupService companySignupService;
 
     /**
@@ -17,7 +17,7 @@ public class SignupController {
      */
     @PostMapping("/company/signup")
     public String signUp(@RequestBody CompanySignupReqDTO companySignupReqDTO){
-        if(companySignupReqDTO.getEmail() == null || companySignupReqDTO.getPassword() == null){
+        if(companySignupReqDTO.getCompanyEmail() == null || companySignupReqDTO.getCompanyPassword() == null){
             return "아이디와 비밀번호를 정확히 입력해주세요";
         }
 

--- a/src/main/java/com/project/finalproject/signup/controller/CompanySignupController.java
+++ b/src/main/java/com/project/finalproject/signup/controller/CompanySignupController.java
@@ -1,5 +1,6 @@
 package com.project.finalproject.signup.controller;
 
+import com.project.finalproject.global.dto.ResponseDTO;
 import com.project.finalproject.signup.dto.CompanySignupReqDTO;
 import com.project.finalproject.signup.service.CompanySignupService;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +17,9 @@ public class CompanySignupController {
      * 기업회원 회원가입
      */
     @PostMapping("/company/signup")
-    public String signUp(@RequestBody CompanySignupReqDTO companySignupReqDTO){
+    public ResponseDTO signUp(@RequestBody CompanySignupReqDTO companySignupReqDTO){
         if(companySignupReqDTO.getCompanyEmail() == null || companySignupReqDTO.getCompanyPassword() == null){
-            return "아이디와 비밀번호를 정확히 입력해주세요";
+            return new ResponseDTO(401, false,"INVALID", "이메일과 비밀번호를 정확히 입력해주세요.");
         }
 
         return companySignupService.signUp(companySignupReqDTO);

--- a/src/main/java/com/project/finalproject/signup/dto/CompanySignupReqDTO.java
+++ b/src/main/java/com/project/finalproject/signup/dto/CompanySignupReqDTO.java
@@ -1,8 +1,10 @@
 package com.project.finalproject.signup.dto;
 
 import com.project.finalproject.company.entity.Company;
-import com.project.finalproject.company.entity.enums.CompanyType;
 import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static com.project.finalproject.company.entity.enums.CompanyType.COMPANY;
 
@@ -13,28 +15,29 @@ import static com.project.finalproject.company.entity.enums.CompanyType.COMPANY;
 @Builder
 public class CompanySignupReqDTO {
 
-    private String email; //회사이메일(겸 아이디)
-    private String password; //비밀번호
+    private String companyEmail; //회사이메일(겸 아이디)
+    private String companyPassword; //비밀번호
     private String companyName; //회사명
-    private String address; //회사주소
-    private String contact; //연락처
-    private String regNum; //사업자번호
-    private String representativeName; //대표자이름
-    private String url; //홈페이지 주소
+    private String companyAddress; //회사주소
+    private String companyContact; //연락처
+    private String companyRegNum; //사업자번호
+    private String companyRepresentative; //대표자이름
+    private String companyUrl; //홈페이지 주소
 
 
     //필요시사용
     public Company toEntity(){
         return Company.builder()
                 .name(companyName)
-                .representativeName(representativeName)
-                .regNum(regNum)
-                .email(email)
-                .password(password)
-                .contact(contact)
-                .address(address)
-                .url(url)
+                .representativeName(companyRepresentative)
+                .regNum(companyRegNum)
+                .email(companyEmail)
+                .password(companyPassword)
+                .contact(companyContact)
+                .address(companyAddress)
+                .url(companyUrl)
                 .companyType(COMPANY)
+                .signupDate(LocalDate.now())
                 .build();
     }
 }

--- a/src/main/java/com/project/finalproject/signup/service/CompanySignupService.java
+++ b/src/main/java/com/project/finalproject/signup/service/CompanySignupService.java
@@ -24,11 +24,11 @@ public class CompanySignupService {
      * 회원가입
      */
     public String signUp(CompanySignupReqDTO reqDTO){
-        if(companySignupRepository.existsCompanyByEmail(reqDTO.getEmail())){
-            return reqDTO.getEmail() + "는 이미 존재하는 아이디 입니다.";
+        if(companySignupRepository.existsCompanyByEmail(reqDTO.getCompanyEmail())){
+            return reqDTO.getCompanyEmail() + "는 이미 존재하는 아이디 입니다.";
         }
 
-        reqDTO.setPassword(passwordEncoding(reqDTO.getPassword()));
+        reqDTO.setCompanyPassword(passwordEncoding(reqDTO.getCompanyPassword()));
 
         Company company = reqDTO.toEntity();
 

--- a/src/main/java/com/project/finalproject/signup/service/CompanySignupService.java
+++ b/src/main/java/com/project/finalproject/signup/service/CompanySignupService.java
@@ -1,6 +1,7 @@
 package com.project.finalproject.signup.service;
 
 import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.global.dto.ResponseDTO;
 import com.project.finalproject.global.jwt.utils.JwtUtil;
 import com.project.finalproject.signup.dto.CompanySignupReqDTO;
 import com.project.finalproject.signup.repository.CompanySignupRepository;
@@ -23,9 +24,9 @@ public class CompanySignupService {
     /**
      * 회원가입
      */
-    public String signUp(CompanySignupReqDTO reqDTO){
+    public ResponseDTO signUp(CompanySignupReqDTO reqDTO){
         if(companySignupRepository.existsCompanyByEmail(reqDTO.getCompanyEmail())){
-            return reqDTO.getCompanyEmail() + "는 이미 존재하는 아이디 입니다.";
+            return new ResponseDTO(401,false,null,reqDTO.getCompanyEmail() + "는 이미 존재하는 아이디 입니다.");
         }
 
         reqDTO.setCompanyPassword(passwordEncoding(reqDTO.getCompanyPassword()));
@@ -34,7 +35,7 @@ public class CompanySignupService {
 
         companySignupRepository.save(company);
 
-        return "회원가입이 완료되었습니다.";
+        return new ResponseDTO(200, true, null, "회원가입이 완료되었습니다.");
     }
 
     /**


### PR DESCRIPTION
## Why need this change? 
- 로그인 기능 구현 및 추가 수정

## Changes ✏️
- 1744ae2 지원자(Applicant) 로그인 기능 구현
- 3495c69 기업(Company) 로그인 기능 구현
- 86552c0 기업(Company) 회원가입 관련 수정
- d996d6d permitUrl 추가(/admin/login)
- df678e4 jwtUtil 수정(토큰 생성시 Long id 값 포함), 그에 따른 JwtExceptionFilter 수정
- 7f6e4cf 기업(Company) 회원가입 관련 수정(처리 결과를 ResponseDTO로 반환)

## Test checklist✅ (optional)
- 지원자 로그인
![지원자로그인](https://user-images.githubusercontent.com/113500922/229855485-3df7a47e-d328-431a-a1ac-7492bbe1e40e.png)

- 기업 로그인
![기업로그인](https://user-images.githubusercontent.com/113500922/229855590-74e09a6f-a0f3-4198-ac38-5a4cd548b22b.png)

- 관리자 로그인
![관리자로그인](https://user-images.githubusercontent.com/113500922/229855640-77218197-e16e-4808-9c50-a608adb1cceb.png)

- 기업 회원가입 결과값 반환타입 수정
![기업회원가입수정](https://user-images.githubusercontent.com/113500922/229863735-68affdb5-6e30-444e-ad4c-4fcffe697d1f.png)

