### PR TITLE
Feat/#53 로그아웃 기능 구현 및 기타 수정

### DIFF
--- a/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
      */
     String[] permitUrl = {"/**",
             "/company/login","/applicant/signup","applicant/checkemail",
-            "/applicant/login","/company/signup", "/refresh","/admin/term/**","/admin/login"};
+            "/applicant/login","/company/signup", "/refresh","/admin/term/**","/admin/login","/terms/**"};
 
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtUtil.java
@@ -176,4 +176,12 @@ public class JwtUtil {
                 .getBody().get("id", Long.class);
     }
 
+    /**
+     * 토큰에서 유효기간 일시 추출
+     */
+    public Date getExpiration(String token) {
+        return Jwts.parser().setSigningKey(jwtProperties.getSecretKey()).parseClaimsJws(token)
+                .getBody().getExpiration();
+    }
+
 }

--- a/src/main/java/com/project/finalproject/logout/controller/LogoutController.java
+++ b/src/main/java/com/project/finalproject/logout/controller/LogoutController.java
@@ -1,4 +1,29 @@
 package com.project.finalproject.logout.controller;
 
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.logout.dto.LogoutReqDTO;
+import com.project.finalproject.logout.service.LogoutService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
 public class LogoutController {
+    private final LogoutService logoutService;
+
+    /**
+     * 로그아웃
+     */
+    @PostMapping("/logout")
+    public ResponseDTO logout(HttpServletRequest request){
+
+        return logoutService.logout(LogoutReqDTO.builder()
+                        .authorizationHeader(request.getHeader(HttpHeaders.AUTHORIZATION))
+                        .refreshHeader(request.getHeader("REFRESH"))
+                        .build());
+    }
 }

--- a/src/main/java/com/project/finalproject/logout/dto/LogoutReqDTO.java
+++ b/src/main/java/com/project/finalproject/logout/dto/LogoutReqDTO.java
@@ -1,4 +1,12 @@
 package com.project.finalproject.logout.dto;
 
+import lombok.*;
+import org.springframework.web.HttpRequestHandler;
+
+@Getter
+@Setter
+@Builder
 public class LogoutReqDTO {
+    private String authorizationHeader;
+    private String refreshHeader;
 }

--- a/src/main/java/com/project/finalproject/logout/service/LogoutService.java
+++ b/src/main/java/com/project/finalproject/logout/service/LogoutService.java
@@ -1,4 +1,47 @@
 package com.project.finalproject.logout.service;
 
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.jwt.utils.JwtUtil;
+import com.project.finalproject.logout.dto.LogoutReqDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class LogoutService {
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 로그아웃
+     */
+    @Transactional(readOnly = true)
+    public ResponseDTO logout(LogoutReqDTO req){
+        //req에서 access와 refresh 토큰을 받아서 redis에 넣어준다. 이때 유효기간 설정 필!
+        String accessToken = jwtUtil.extractToken(req.getAuthorizationHeader());
+        String refreshToken = jwtUtil.extractToken(req.getRefreshHeader());
+
+        Date accessExpirationDate = jwtUtil.getExpiration(accessToken);
+        Date refreshExpirationDate = jwtUtil.getExpiration(refreshToken);
+        Date current = new Date();
+
+        Instant accessInstant = accessExpirationDate.toInstant();
+        Instant refreshInstant = refreshExpirationDate.toInstant();
+        Instant currentInstant = current.toInstant();
+
+        stringRedisTemplate.opsForValue().set(accessToken,"AccessToken", Duration.between(currentInstant, accessInstant));
+        stringRedisTemplate.opsForValue().set(refreshToken,"RefreshToken",Duration.between(currentInstant, refreshInstant));
+
+        return new ResponseDTO(200, true, null, "로그아웃 성공!");
+    }
 }


### PR DESCRIPTION
## Why need this change? 
- 로그아웃 기능 구현 및 기능 구현 중 필요에 의한 수정

## Changes ✏️
- ab8b960 로그아웃 기능 구현
- 9320156 permitUrl 추가(/terms/**)
- 7e5d54e JwtFilter에서 Redis를 확인하는 로직 수정
- c3af20b JwtUtil 수정(메서드 추가)

## Test checklist✅ (optional)
- 로그아웃 기능
![로그아웃성공](https://user-images.githubusercontent.com/113500922/230017330-1521e103-2ebd-4b50-aa7f-2c89b6730acf.png)

- permitUrl 추가
![permiturl추가](https://user-images.githubusercontent.com/113500922/230017401-f3f71f59-1b27-4594-bcd8-9e1b5c4cec14.png)

- 로그아웃 시 Redis에 Access, Refresh토큰 모두 저장. 만료 시간 지나면 Redis에서 자동 삭제
![redis저장상태](https://user-images.githubusercontent.com/113500922/230017655-50fabe99-ba10-4e8b-8e0c-b652784edb7d.png)

- JwtFilter 수정으로, Redis에 있는 토큰으로 접근하려 하면 로그인 페이지로 redirect
![redis토큰사용하려할때](https://user-images.githubusercontent.com/113500922/230017957-87e395e8-0954-4fa0-acff-1f1862658879.png)



