### PR TITLE
Feature/#116 관리자 개인회원 목록조회

### DIFF
--- a/src/main/java/com/project/finalproject/company/controller/AdminController.java
+++ b/src/main/java/com/project/finalproject/company/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.project.finalproject.company.controller;
 
+import com.project.finalproject.company.dto.AdminApplicantRes;
 import com.project.finalproject.company.dto.AdminCompanyRes;
 import com.project.finalproject.company.entity.enums.CompanyType;
 import com.project.finalproject.company.service.AdminService;
@@ -26,4 +27,13 @@ public class AdminController {
 
         return new ResponseDTO<>().ok(companyList, "companyList success");
     }
+
+    @GetMapping("/applicants")
+    public ResponseDTO<?> showApplicantList() {
+        //TODO : 토큰 완성되면 개인회원목록조회 파라미터 수정하기
+        List<AdminApplicantRes.ApplicantListDTO> applicantList = adminService.showApplicantList();
+
+        return new ResponseDTO<>().ok(applicantList, "applicantList success");
+    }
+
 }

--- a/src/main/java/com/project/finalproject/company/dto/AdminApplicantRes.java
+++ b/src/main/java/com/project/finalproject/company/dto/AdminApplicantRes.java
@@ -1,0 +1,35 @@
+package com.project.finalproject.company.dto;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class AdminApplicantRes {
+    @Getter
+    public static class ApplicantListDTO {
+        private Long applicantId; //지원자 id
+        private String email; //지원자 email
+        private String name; //지원자 이름
+        private LocalDate birthDate; //지원자 생년월일
+        private String gender;  //지원자 성별
+        private String contact; //지원자 연락처
+        private String education;   //지원자 학력
+        private String workExperience; //지원자 경력
+        private String sector;  //지원직무
+
+    @Builder
+        public ApplicantListDTO(Applicant applicant) {
+        this.applicantId = applicant.getId();
+        this.email = applicant.getEmail();
+        this.name = applicant.getName();
+        this.birthDate = applicant.getBirthDate();
+        this.gender = applicant.getGender().getGender();
+        this.contact = applicant.getContact();
+        this.education = applicant.getEducation().getEducation();
+        this.workExperience = applicant.getWorkExperience().getWorkExperience();
+        this.sector = applicant.getSector().getSector();
+        }
+    }
+}

--- a/src/main/java/com/project/finalproject/company/service/AdminService.java
+++ b/src/main/java/com/project/finalproject/company/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.project.finalproject.company.service;
 
+import com.project.finalproject.company.dto.AdminApplicantRes;
 import com.project.finalproject.company.dto.AdminCompanyRes;
 import com.project.finalproject.company.entity.enums.CompanyType;
 import org.springframework.stereotype.Service;
@@ -10,5 +11,8 @@ public interface AdminService {
 
     // 기업회원 목록조회
     List<AdminCompanyRes.CompanyListDTO> showCompanyList(CompanyType companyType);
+
+    //개인회원 목록조회
+    List<AdminApplicantRes.ApplicantListDTO> showApplicantList();
 
 }

--- a/src/main/java/com/project/finalproject/company/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/project/finalproject/company/service/impl/AdminServiceImpl.java
@@ -1,14 +1,13 @@
 package com.project.finalproject.company.service.impl;
 
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.applicant.repository.ApplicantRepository;
+import com.project.finalproject.company.dto.AdminApplicantRes;
 import com.project.finalproject.company.dto.AdminCompanyRes;
-import com.project.finalproject.company.entity.Company;
 import com.project.finalproject.company.entity.enums.CompanyType;
-import com.project.finalproject.company.exception.CompanyException;
-import com.project.finalproject.company.exception.CompanyExceptionType;
 import com.project.finalproject.company.repository.CompanyRepository;
 import com.project.finalproject.company.service.AdminService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,11 +19,20 @@ import java.util.stream.Collectors;
 public class AdminServiceImpl implements AdminService {
 
     private final CompanyRepository companyRepository;
+    private final ApplicantRepository applicantRepository;
 
     @Transactional(readOnly = true)
     @Override
     public List<AdminCompanyRes.CompanyListDTO> showCompanyList(CompanyType companyType) {
         return companyRepository.findByCompanyType(companyType).stream()
                 .map(AdminCompanyRes.CompanyListDTO::new).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<AdminApplicantRes.ApplicantListDTO> showApplicantList() {
+        List<Applicant> applicants = applicantRepository.findAll();
+        return applicants.stream()
+                .map(AdminApplicantRes.ApplicantListDTO::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
      */
     String[] permitUrl = {"/**",
             "/company/login","/applicant/signup","applicant/checkemail",
-            "/applicant/login","/company/signup", "/refresh","/admin/term/**","/admin/login","/terms/**"};
+            "/applicant/login","/company/signup", "/refresh","/admin/term/**","/admin/login","/terms/**","/admin/**"};
 
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;


### PR DESCRIPTION
## Why need this change? 
- 관리자가 조회하는 개인회원 목록

## Changes ✏️
- b07f659070cdbf14b9b75c30df3d38b622562069 : 개인회원 관련 DTO 생성, 목록조회용 dto 추가
- e91ea2b8227d4da3602bfdc5ac5feb51700d09b7 : 개인회원 목록조회 service
- 6480ec5fc880804f433fe0ab59d33c97546a89eb : 개인회원 목록조회 serviceimpl
- 679e77bc52c1709bb82299846a45a650fd1bf22e : 개인회원 목록조회 controller
- 6abb9e350533ed2a8acacffc896dbe0051fe8a8a : 개인회원 목록조회 token 미적용 url 임시등록

## Test checklist✅ (optional)
- [ ] 토큰 적용 후 수정하기
