### PR TITLE
Feat/#109 회원탈퇴 기능 구현 및 기타 수정

### DIFF
--- a/src/main/java/com/project/finalproject/applicant/entity/Applicant.java
+++ b/src/main/java/com/project/finalproject/applicant/entity/Applicant.java
@@ -67,5 +67,8 @@ public class Applicant {
 
     @Column(name = "applicant_disable_date")
     private LocalDate disableDate; //휴면 전환 날짜
-
+    public void applicantResign(String email, LocalDate disableDate) {
+        this.email = email;
+        this.disableDate = disableDate;
+    }
 }

--- a/src/main/java/com/project/finalproject/company/entity/Company.java
+++ b/src/main/java/com/project/finalproject/company/entity/Company.java
@@ -58,8 +58,11 @@ public class Company {
     @Column(name = "company_signup_date", updatable = false)
     private LocalDate signupDate; //가입날짜
 
-    @Column(name = "company_url")
+    @Column(name = "company_disable_date")
     private LocalDate disableDate; //탈퇴날짜
 
-
+    public void companyResign(String email, LocalDate disableDate) {
+        this.email = email;
+        this.disableDate = disableDate;
+    }
 }

--- a/src/main/java/com/project/finalproject/logout/dto/LogoutReqDTO.java
+++ b/src/main/java/com/project/finalproject/logout/dto/LogoutReqDTO.java
@@ -1,7 +1,6 @@
 package com.project.finalproject.logout.dto;
 
 import lombok.*;
-import org.springframework.web.HttpRequestHandler;
 
 @Getter
 @Setter

--- a/src/main/java/com/project/finalproject/logout/repository/LogoutRepository.java
+++ b/src/main/java/com/project/finalproject/logout/repository/LogoutRepository.java
@@ -1,4 +1,0 @@
-package com.project.finalproject.logout.repository;
-
-public class LogoutRepository {
-}

--- a/src/main/java/com/project/finalproject/resign/controller/ResignController.java
+++ b/src/main/java/com/project/finalproject/resign/controller/ResignController.java
@@ -1,0 +1,35 @@
+package com.project.finalproject.resign.controller;
+
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.jwt.utils.JwtUtil;
+import com.project.finalproject.resign.dto.ResignDTO;
+import com.project.finalproject.resign.service.ResignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class ResignController {
+
+    private final ResignService resignService;
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 회원탈퇴(탈퇴 날짜를 저장하고, 이메일만 지운다.)
+     */
+    @PostMapping("/deactive")
+    public ResponseDTO resign(HttpServletRequest request){
+        String token = jwtUtil.extractToken(request.getHeader(HttpHeaders.AUTHORIZATION));
+        Long id = jwtUtil.getId(token);
+        String role = jwtUtil.getRole(token);
+
+        return resignService.resign(ResignDTO.builder()
+                        .id(id)
+                        .role(role)
+                        .build());
+    }
+}

--- a/src/main/java/com/project/finalproject/resign/dto/ResignDTO.java
+++ b/src/main/java/com/project/finalproject/resign/dto/ResignDTO.java
@@ -1,0 +1,11 @@
+package com.project.finalproject.resign.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+public class ResignDTO {
+    private Long id;
+    private String role;
+}

--- a/src/main/java/com/project/finalproject/resign/repository/ApplicantResignRepository.java
+++ b/src/main/java/com/project/finalproject/resign/repository/ApplicantResignRepository.java
@@ -1,0 +1,12 @@
+package com.project.finalproject.resign.repository;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplicantResignRepository extends JpaRepository<Applicant, Long> {
+
+    Optional<Applicant> findApplicantById(Long id);
+
+}

--- a/src/main/java/com/project/finalproject/resign/repository/ApplicationResigngRepository.java
+++ b/src/main/java/com/project/finalproject/resign/repository/ApplicationResigngRepository.java
@@ -1,0 +1,11 @@
+package com.project.finalproject.resign.repository;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.application.entity.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationResigngRepository extends JpaRepository<Application, Long> {
+
+    void deleteApplicationByApplicant(Applicant applicant);
+
+}

--- a/src/main/java/com/project/finalproject/resign/repository/CompanyResignRepository.java
+++ b/src/main/java/com/project/finalproject/resign/repository/CompanyResignRepository.java
@@ -1,0 +1,12 @@
+package com.project.finalproject.resign.repository;
+
+import com.project.finalproject.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CompanyResignRepository extends JpaRepository<Company, Long> {
+
+    Optional<Company> findCompanyById(Long id);
+
+}

--- a/src/main/java/com/project/finalproject/resign/service/ResignService.java
+++ b/src/main/java/com/project/finalproject/resign/service/ResignService.java
@@ -1,0 +1,46 @@
+package com.project.finalproject.resign.service;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.resign.dto.ResignDTO;
+import com.project.finalproject.resign.repository.ApplicantResignRepository;
+import com.project.finalproject.resign.repository.ApplicationResigngRepository;
+import com.project.finalproject.resign.repository.CompanyResignRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ResignService {
+    private final ApplicantResignRepository applicantResignRepository;
+    private final CompanyResignRepository companyResignRepository;
+    private final ApplicationResigngRepository applicationResigngRepository;
+
+    /**
+     * 회원탈퇴(탈퇴 날짜를 저장하고, 이메일만 지운다.)
+     */
+    public ResponseDTO resign(ResignDTO resignDTO){
+        if(resignDTO.getRole().equals("USER")){
+            Applicant findApplicant = applicantResignRepository.findApplicantById(resignDTO.getId()).orElseThrow();
+            applicationResigngRepository.deleteApplicationByApplicant(findApplicant); //지원서를 먼저 지우고
+            findApplicant.applicantResign(null,LocalDate.now());
+            applicantResignRepository.save(findApplicant); //email 삭제 및 탈퇴 날짜 입력
+            return new ResponseDTO(200, true, null, "회원탈퇴가 정상적으로 처리되었습니다.");
+        }
+        else if(resignDTO.getRole().equals("COMPANY")){
+            Company findCompany = companyResignRepository.findCompanyById(resignDTO.getId()).orElseThrow();
+            findCompany.companyResign(null,LocalDate.now());
+            companyResignRepository.save(findCompany);
+            return new ResponseDTO(200, true, null, "회원탈퇴가 정상적으로 처리되었습니다.");
+        }
+        else{
+            return new ResponseDTO(400, false, null,"관리자는 탈퇴할 수 없습니다.");
+        }
+
+    }
+}


### PR DESCRIPTION
## Why need this change? 
- 회원탈퇴 기능 구현

## Changes ✏️
- f727f65 Applicant, Company 엔티티에 메서드 추가, Company 엔티티에 잘못 기입되어 있던 컬럼명 수정
- 642e6d3 불필요한 LogoutRepository 삭제 및 LogoutReqDTO 수정
- d66d524 회원탈퇴 기능 구현(탈퇴시 지원자의 경우 관련 지원서도 삭제)

## Test checklist✅ (optional)
- 회원탈퇴 성공
![회원탈퇴성공](https://user-images.githubusercontent.com/113500922/230287130-ac4abdaa-1d07-4838-a188-a5704a86c606.png)

- 탈퇴 시 db 상태(email 지워지고, 탈퇴한 날짜 입력됨)
![탈퇴시db상태](https://user-images.githubusercontent.com/113500922/230287206-bd6d8542-c7ed-45aa-a5b8-ab8a5ebfdec1.png)
