### PR TITLE
Feat/#108 비밀번호 변경 및 초기화 기능 구현

### DIFF
--- a/src/main/java/com/project/finalproject/applicant/entity/Applicant.java
+++ b/src/main/java/com/project/finalproject/applicant/entity/Applicant.java
@@ -71,4 +71,7 @@ public class Applicant {
         this.email = email;
         this.disableDate = disableDate;
     }
+    public void changeApplicantPassword(String password){
+        this.password = password;
+    }
 }

--- a/src/main/java/com/project/finalproject/company/entity/Company.java
+++ b/src/main/java/com/project/finalproject/company/entity/Company.java
@@ -90,4 +90,8 @@ public class Company {
                 .disableDate(disableDate)
                 .build();
     }
+
+    public void changeCompanyPassword(String password){
+        this.password = password;
+    }
 }

--- a/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/finalproject/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
      */
     String[] permitUrl = {"/**",
             "/company/login","/applicant/signup","applicant/checkemail",
-            "/applicant/login","/company/signup", "/refresh","/admin/login","/terms/**"};
+            "/applicant/login","/company/signup", "/refresh","/admin/term/**","/admin/login","/terms/**","/reset"};
 
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;

--- a/src/main/java/com/project/finalproject/global/jwt/utils/JwtFilter.java
+++ b/src/main/java/com/project/finalproject/global/jwt/utils/JwtFilter.java
@@ -33,6 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
         put("/applicant/signup","permit");
         put("/refresh","permit");
         put("/admin/login","permit");
+        put("/reset","permit");
     }};
 
     @Autowired

--- a/src/main/java/com/project/finalproject/password/controller/PasswordController.java
+++ b/src/main/java/com/project/finalproject/password/controller/PasswordController.java
@@ -1,0 +1,45 @@
+package com.project.finalproject.password.controller;
+
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.jwt.utils.JwtUtil;
+import com.project.finalproject.password.dto.PasswordDTO;
+import com.project.finalproject.password.service.PasswordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.mail.MessagingException;
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class PasswordController {
+
+    private final PasswordService passwordService;
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 로그인한 상태에서 비밀번호 변경
+     */
+    @PostMapping("/change")
+    public ResponseDTO changePassword(@RequestBody PasswordDTO passwordDTO, HttpServletRequest request){
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String token = jwtUtil.extractToken(authorizationHeader);
+        String role = jwtUtil.getRole(token);
+        Long id = jwtUtil.getId(token);
+        passwordDTO.setRole(role);
+        passwordDTO.setId(id);
+
+        return passwordService.changePassword(passwordDTO);
+    }
+
+    /**
+     * 로그인하지 않은 상태에서 비밀번호 초기화
+     */
+    @PostMapping("/reset")
+    public ResponseDTO resetPassword(@RequestBody PasswordDTO passwordDTO) throws MessagingException {
+        return passwordService.resetPassword(passwordDTO);
+    }
+}

--- a/src/main/java/com/project/finalproject/password/dto/PasswordDTO.java
+++ b/src/main/java/com/project/finalproject/password/dto/PasswordDTO.java
@@ -1,0 +1,14 @@
+package com.project.finalproject.password.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+public class PasswordDTO {
+    private String email;
+    private String password;
+    private String role;
+    private String name;
+    private Long id;
+}

--- a/src/main/java/com/project/finalproject/password/repository/ApplicantPasswordRepository.java
+++ b/src/main/java/com/project/finalproject/password/repository/ApplicantPasswordRepository.java
@@ -1,0 +1,13 @@
+package com.project.finalproject.password.repository;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplicantPasswordRepository extends JpaRepository<Applicant, Long> {
+
+    Optional<Applicant> findApplicantByEmailAndName(String email, String name);
+    Optional<Applicant> findApplicantById(Long id);
+    Boolean existsApplicantByEmailAndName(String email, String name);
+}

--- a/src/main/java/com/project/finalproject/password/repository/CompanyPasswordRepository.java
+++ b/src/main/java/com/project/finalproject/password/repository/CompanyPasswordRepository.java
@@ -1,0 +1,13 @@
+package com.project.finalproject.password.repository;
+
+import com.project.finalproject.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CompanyPasswordRepository extends JpaRepository<Company, Long> {
+
+    Optional<Company> findCompanyByEmailAndName(String email, String name);
+    Optional<Company> findCompanyById(Long id);
+    Boolean existsCompanyByEmailAndName(String email, String name);
+}

--- a/src/main/java/com/project/finalproject/password/service/PasswordService.java
+++ b/src/main/java/com/project/finalproject/password/service/PasswordService.java
@@ -1,0 +1,122 @@
+package com.project.finalproject.password.service;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.password.dto.PasswordDTO;
+import com.project.finalproject.password.repository.ApplicantPasswordRepository;
+import com.project.finalproject.password.repository.CompanyPasswordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@ConstructorBinding
+public class PasswordService {
+
+    private final ApplicantPasswordRepository applicantPasswordRepository;
+    private final CompanyPasswordRepository companyPasswordRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String sender;
+
+    /**
+     * 로그인한 상태에서 비밀번호 변경
+     */
+    public ResponseDTO changePassword(PasswordDTO passwordDTO){
+
+        String newPassword = passwordDTO.getPassword();
+        String role = passwordDTO.getRole();
+        Long id = passwordDTO.getId();
+
+        if(role.equals("USER")){
+            Applicant findApplicant = applicantPasswordRepository.findApplicantById(id).orElseThrow();
+            findApplicant.changeApplicantPassword(passwordEncoding(newPassword));
+            applicantPasswordRepository.save(findApplicant);
+
+            return new ResponseDTO(200, true, null, "비밀번호가 변경되었습니다.");
+        }
+        else{
+            Company findCompany = companyPasswordRepository.findCompanyById(id).orElseThrow();
+            findCompany.changeCompanyPassword(passwordEncoding(newPassword));
+            companyPasswordRepository.save(findCompany);
+
+            return new ResponseDTO(200, true, null, "비밀번호가 변경되었습니다.");
+        }
+    }
+
+    /**
+     * 로그인하지 않은 상태에서 비밀번호 초기화
+     */
+    public ResponseDTO resetPassword(PasswordDTO passwordDTO) throws MessagingException {
+        String email = passwordDTO.getEmail();
+        String name = passwordDTO.getName();
+        String resetPassword = getRandomPassword(7);
+
+        StringBuilder text = new StringBuilder();
+        text.append("안녕하세요, 메디메치입니다.").append("\n");
+        text.append("임시 비밀번호를 다음과 같이 안내드리오니, 로그인 후 반드시 비밀번호를 재설정하시기 바랍니다.").append("\n");
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true,"UTF-8");
+        mimeMessageHelper.setFrom(sender);
+        mimeMessageHelper.setTo(email);
+        mimeMessageHelper.setSubject("[메디메치] 임시 비밀번호 안내");
+
+
+        if(applicantPasswordRepository.existsApplicantByEmailAndName(email, name)){
+
+            Applicant findApplicant = applicantPasswordRepository.findApplicantByEmailAndName(email, name).orElseThrow();
+            findApplicant.changeApplicantPassword(passwordEncoding(resetPassword));
+            applicantPasswordRepository.save(findApplicant);
+
+            text.append("임시비밀번호 : ").append(resetPassword);
+            mimeMessageHelper.setText(text.toString());
+            javaMailSender.send(mimeMessage);
+
+            return new ResponseDTO(200, true, null, "초기화 된 비밀번호가 이메일로 발송되었습니다.");
+        }
+        else if(companyPasswordRepository.existsCompanyByEmailAndName(email, name)){
+
+            Company findCompany = companyPasswordRepository.findCompanyByEmailAndName(email, name).orElseThrow();
+            findCompany.changeCompanyPassword(passwordEncoding(resetPassword));
+            companyPasswordRepository.save(findCompany);
+
+            text.append("임시비밀번호 : ").append(resetPassword);
+            mimeMessageHelper.setText(text.toString());
+            javaMailSender.send(mimeMessage);
+
+            return new ResponseDTO(200, true, null, "초기화 된 비밀번호가 이메일로 발송되었습니다.");
+        }
+        else{
+            return new ResponseDTO(400, false, null, "존재하지 않는 사용자입니다.");
+        }
+    }
+
+    /**
+     * 비밀번호 암호화
+     */
+    private String passwordEncoding(String password){
+        return passwordEncoder.encode(password);
+    }
+
+    /**
+     * 임시비밀번호 생성
+     */
+    private String getRandomPassword(int size){
+        return RandomStringUtils.randomAlphanumeric(size);
+    }
+}

--- a/src/main/java/com/project/finalproject/signup/service/CompanySignupService.java
+++ b/src/main/java/com/project/finalproject/signup/service/CompanySignupService.java
@@ -2,7 +2,6 @@ package com.project.finalproject.signup.service;
 
 import com.project.finalproject.company.entity.Company;
 import com.project.finalproject.global.dto.ResponseDTO;
-import com.project.finalproject.global.jwt.utils.JwtUtil;
 import com.project.finalproject.signup.dto.CompanySignupReqDTO;
 import com.project.finalproject.signup.repository.CompanySignupRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import javax.transaction.Transactional;
 public class CompanySignupService {
 
     private final CompanySignupRepository companySignupRepository;
-    private final JwtUtil jwtUtil;
 
     private final PasswordEncoder passwordEncoder;
 


### PR DESCRIPTION
## Why need this change? 
- 비밀번호 변경 및 초기화 기능 구현

## Changes ✏️
- 82c4b0b 비밀번호 변경, 초기화시 필요한 메서드 추가(Applicant, Company 엔티티)
- c942fb8 불필요한 import 삭제
- 65ea201 permitUrl 추가(비밀번호 초기화 "/reset")
- a60df41 비밀번호 변경 및 초기화 기능 구현(초기화 시, 임시 비밀번호 메일 발송)

## Test checklist✅ (optional)
- 로그인 상태에서 비밀번호 변경하고 변경 전 비밀번호로 로그인 시도 시 실패
![변경전비번로그인](https://user-images.githubusercontent.com/113500922/230383085-f2f73105-ffc6-462f-9d74-f64a0b956dac.png)

- 변경 후 바뀐 비밀 번호로 로그인
![변경후비번로그인](https://user-images.githubusercontent.com/113500922/230383170-18cdfdb1-d8d1-4fc4-9f87-bdd5e565f976.png)

- 비밀번호를 잊어버렸을 때 초기화 요청
![임시비밀번호메일발송성공](https://user-images.githubusercontent.com/113500922/230383368-927f2d02-afdb-4a78-9ab5-6bb1444ee6b8.png)

- 초기화 된 비밀번호로 로그인 성공
![바뀐비밀번호로로그인성공](https://user-images.githubusercontent.com/113500922/230383516-e849a96c-fd26-4a99-9adb-8e833726d17f.png)

