### PR TITLE
#110 공고 조회 기능 구현 및 수정

### DIFF
--- a/src/main/java/com/project/finalproject/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/project/finalproject/global/exception/CustomExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.project.finalproject.global.exception;
 
 import com.project.finalproject.company.exception.CompanyException;
-import com.project.finalproject.company.exception.CompanyExceptionType;
 import com.project.finalproject.global.dto.ErrorDTO;
 import com.project.finalproject.global.exception.base.CustomException;
 import com.project.finalproject.jobpost.exception.JobpostException;

--- a/src/main/java/com/project/finalproject/global/jwt/JwtUtilException.java
+++ b/src/main/java/com/project/finalproject/global/jwt/JwtUtilException.java
@@ -1,8 +1,5 @@
 package com.project.finalproject.global.jwt;
 
-import com.project.finalproject.global.exception.base.CustomException;
-import com.project.finalproject.global.exception.base.CustomExceptionType;
-
 public class JwtUtilException extends RuntimeException{
 
     private JwtUtilExceptionType jwtUtilExceptionType;
@@ -14,4 +11,5 @@ public class JwtUtilException extends RuntimeException{
     public JwtUtilExceptionType getExceptionType() {
         return jwtUtilExceptionType;
     }
+
 }

--- a/src/main/java/com/project/finalproject/global/jwt/JwtUtilExceptionType.java
+++ b/src/main/java/com/project/finalproject/global/jwt/JwtUtilExceptionType.java
@@ -1,6 +1,5 @@
 package com.project.finalproject.global.jwt;
 
-import com.project.finalproject.global.exception.base.CustomExceptionType;
 import org.springframework.http.HttpStatus;
 
 public enum JwtUtilExceptionType {

--- a/src/main/java/com/project/finalproject/jobpost/entity/enums/JobpostWorkExperience.java
+++ b/src/main/java/com/project/finalproject/jobpost/entity/enums/JobpostWorkExperience.java
@@ -2,7 +2,7 @@ package com.project.finalproject.jobpost.entity.enums;
 
 public enum JobpostWorkExperience {
     NEWCOMER("신입"),
-    OEN_YEAR("1년차"),
+    ONE_YEAR("1년차"),
     TWO_YEAR("2년차"),
     THREE_YEAR("3년차"),
     FOUR_YEAR("4년차"),

--- a/src/main/java/com/project/finalproject/searchpost/controller/SearchPostController.java
+++ b/src/main/java/com/project/finalproject/searchpost/controller/SearchPostController.java
@@ -1,0 +1,45 @@
+package com.project.finalproject.searchpost.controller;
+
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.searchpost.dto.PostReqDTO;
+import com.project.finalproject.searchpost.dto.PostResDTO;
+import com.project.finalproject.searchpost.service.SearchPostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class SearchPostController {
+
+    private final SearchPostService searchPostService;
+
+    /**
+     * 공고 조건 검색
+     */
+    @GetMapping("/jobposts/search/{type}")
+    public Page<PostResDTO> searchPosts(@PathVariable String type,
+                                   @RequestBody PostReqDTO reqDTO,
+                                   @PageableDefault Pageable pageable){
+        return searchPostService.searchPost(type, reqDTO, pageable);
+    }
+
+    /**
+     * 전체 공고 조회
+     */
+    @GetMapping("/jobposts/posts")
+    public Page<PostResDTO> allPosts(@PageableDefault Pageable pageable){
+        return searchPostService.allPosts(pageable);
+    }
+
+    /**
+     * 상세 공고 조회
+     */
+    @GetMapping("/jobposts/posts/{postId}")
+    public ResponseDTO detailPost(@PathVariable Long postId){
+
+        return searchPostService.detailPost(postId);
+    }
+}

--- a/src/main/java/com/project/finalproject/searchpost/dto/PostReqDTO.java
+++ b/src/main/java/com/project/finalproject/searchpost/dto/PostReqDTO.java
@@ -1,0 +1,14 @@
+package com.project.finalproject.searchpost.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostReqDTO {
+
+    private String keyword;
+
+}

--- a/src/main/java/com/project/finalproject/searchpost/dto/PostResDTO.java
+++ b/src/main/java/com/project/finalproject/searchpost/dto/PostResDTO.java
@@ -1,0 +1,87 @@
+package com.project.finalproject.searchpost.dto;
+
+import com.project.finalproject.jobpost.entity.Jobpost;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostResDTO {
+
+    private Long jobpostId;
+    private String jobpostTitle;
+    private String jobpostSector;
+    private String jobpostEducation;
+    private String jobpostWorkExperience;
+    private Integer jobpostRecruitNum;
+    private String jobpostDueDate;
+    private String jobpostStatus;
+    private String jobpostFilePath;
+    private String companyName;
+
+    public PostResDTO(Jobpost jobpost){
+
+        this.jobpostId = jobpost.getId();
+
+        this.jobpostTitle = jobpost.getTitle();
+
+        switch (jobpost.getSector()){
+            case DOCTOR: this.jobpostSector = "의사";
+            break;
+            case NURSE: this.jobpostSector = "간호사";
+            break;
+            case NURSE_AIDE: this.jobpostSector = "간호조무사";
+            break;
+            case MEDICAL_RECORDS_PROFESSIONAL: this.jobpostSector = "원무과";
+            break;
+            case MEDICAL_TECHNICIAN: this.jobpostSector = "의료기사";
+            break;
+        }
+
+        switch (jobpost.getEducation()){
+            case HIGH_SCHOOL: this.jobpostEducation = "고졸";
+            break;
+            case JUNIOR_COLLEGE: this.jobpostEducation = "초대졸";
+            break;
+            case UNIVERSITY: this.jobpostEducation = "대졸";
+            break;
+            case MASTER_AND_DOCTOR: this.jobpostEducation = "석박사";
+            break;
+        }
+
+        switch (jobpost.getExperience()){
+            case NEWCOMER: this.jobpostWorkExperience = "신입";
+            break;
+            case ONE_YEAR: this.jobpostWorkExperience = "1년차";
+            break;
+            case TWO_YEAR: this.jobpostWorkExperience = "2년차";
+            break;
+            case THREE_YEAR: this.jobpostWorkExperience = "3년차";
+            break;
+            case FOUR_YEAR: this.jobpostWorkExperience = "4년차";
+            break;
+            case FIVE_YEAR_OVER: this.jobpostWorkExperience = "5년차 이상";
+            break;
+        }
+
+        this.jobpostRecruitNum = jobpost.getRecruitNum();
+
+        this.jobpostDueDate = String.valueOf(jobpost.getDueDate());
+
+        switch (jobpost.getStatus()){
+            case OPEN: this.jobpostStatus = "모집중";
+            break;
+            case CLOSED: this.jobpostStatus = "마감";
+            break;
+            case DISCARD: this.jobpostStatus = "폐기";
+            break;
+        }
+
+        this.jobpostFilePath = jobpost.getFilepath();
+
+        this.companyName = jobpost.getCompany().getName();
+
+    }
+}

--- a/src/main/java/com/project/finalproject/searchpost/repository/SearchCompanyRepository.java
+++ b/src/main/java/com/project/finalproject/searchpost/repository/SearchCompanyRepository.java
@@ -1,0 +1,10 @@
+package com.project.finalproject.searchpost.repository;
+
+import com.project.finalproject.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SearchCompanyRepository extends JpaRepository<Company, Long> {
+    Optional<Company> findCompanyByName(String name);
+}

--- a/src/main/java/com/project/finalproject/searchpost/repository/SearchPostRepository.java
+++ b/src/main/java/com/project/finalproject/searchpost/repository/SearchPostRepository.java
@@ -1,0 +1,24 @@
+package com.project.finalproject.searchpost.repository;
+
+import com.project.finalproject.applicant.entity.enums.Sector;
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.jobpost.entity.Jobpost;
+import com.project.finalproject.jobpost.entity.enums.JobpostEducation;
+import com.project.finalproject.jobpost.entity.enums.JobpostWorkExperience;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface SearchPostRepository extends JpaRepository<Jobpost, Long> {
+
+    Page<Jobpost> findAll(Pageable pageable);
+    Page<Jobpost> findAllBySector(Sector sector, Pageable pageable);
+    Page<Jobpost> findAllByEducation(JobpostEducation education, Pageable pageable);
+    Page<Jobpost> findAllByExperience(JobpostWorkExperience experience, Pageable pageable);
+    Page<Jobpost> findAllByTitleContains(String title, Pageable pageable);
+    Page<Jobpost> findAllByCompany(Company company, Pageable pageable);
+
+    @Override
+    Optional<Jobpost> findById(Long postId);
+}

--- a/src/main/java/com/project/finalproject/searchpost/service/SearchPostService.java
+++ b/src/main/java/com/project/finalproject/searchpost/service/SearchPostService.java
@@ -1,0 +1,67 @@
+package com.project.finalproject.searchpost.service;
+
+import com.project.finalproject.applicant.entity.enums.Sector;
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.exception.CustomExceptionHandler;
+import com.project.finalproject.global.exception.GlobalException;
+import com.project.finalproject.global.exception.GlobalExceptionType;
+import com.project.finalproject.jobpost.entity.enums.JobpostEducation;
+import com.project.finalproject.jobpost.entity.enums.JobpostWorkExperience;
+import com.project.finalproject.searchpost.dto.PostReqDTO;
+import com.project.finalproject.searchpost.dto.PostResDTO;
+import com.project.finalproject.searchpost.repository.SearchCompanyRepository;
+import com.project.finalproject.searchpost.repository.SearchPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SearchPostService {
+
+    private final SearchPostRepository searchPostRepository;
+    private final SearchCompanyRepository searchCompanyRepository;
+
+    /**
+     * 공고 조건 검색
+     */
+    public Page<PostResDTO> searchPost(String type, PostReqDTO reqDTO, Pageable pageable) {
+        String keyword = reqDTO.getKeyword();
+
+        //검색한 회사가 없는 경우 예외 발생시킴
+        //나머지는 값이 없으면 빈 페이지들을 반환
+        switch (type) {
+            case "직무":
+                return searchPostRepository.findAllBySector(Sector.valueOf(keyword), pageable).map(PostResDTO::new);
+            case "학력":
+                return searchPostRepository.findAllByEducation(JobpostEducation.valueOf(keyword), pageable).map(PostResDTO::new);
+            case "경력":
+                return searchPostRepository.findAllByExperience(JobpostWorkExperience.valueOf(keyword), pageable).map(PostResDTO::new);
+            case "공고제목":
+                return searchPostRepository.findAllByTitleContains(keyword, pageable).map(PostResDTO::new);
+            case "회사":
+                Company findCompany = searchCompanyRepository.findCompanyByName(keyword).orElseThrow(()-> new GlobalException(GlobalExceptionType.NOT_FOUND));
+                return searchPostRepository.findAllByCompany(findCompany, pageable).map(PostResDTO::new);
+        }
+        return null;
+    }
+
+        /**
+         * 전체 공고 조회
+         */
+        public Page<PostResDTO> allPosts (Pageable pageable){
+            return searchPostRepository.findAll(pageable).map(PostResDTO::new);
+        }
+
+        /**
+         * 상세 공고 조회
+         */
+        public ResponseDTO detailPost (Long postId){
+            return new ResponseDTO(200, true, searchPostRepository.findById(postId).map(PostResDTO::new).orElseThrow(), "공고 상세조회입니다.");
+        }
+}


### PR DESCRIPTION
## Why need this change? 
- 공고 검색 기능 구현
- 조건 검색, 전체 검색, 상세 검색
- 공고 10개씩 페이지네이션 처리

## Changes ✏️
- b56d43d 오타 수정
- cf3c038 기능구현을 위한 DTO 생성
- 1856a65 공고 검색 기능 구현

## Test checklist✅ (optional)
- 공고 조건 검색시(회사로 검색시)
![공고조건검색(회사)](https://user-images.githubusercontent.com/113500922/230712271-fe50adb4-b163-40d7-974c-f1b64f20d55c.png)

- 전체 공고 조회
![전체공고조회](https://user-images.githubusercontent.com/113500922/230712279-0dfe17f4-1c78-4d1c-850c-033e8ffd2521.png)

- 공고 상세 조회
![상세공고조회](https://user-images.githubusercontent.com/113500922/230712287-440cf917-52e4-449c-988b-203a657acca4.png)
