### PR TITLE
Fix : Changed the way applicant resume is retrieved

### DIFF
--- a/src/main/java/com/project/finalproject/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/project/finalproject/applicant/controller/ApplicantController.java
@@ -131,17 +131,27 @@ public class ApplicantController {
         }
     }
 
-    // 이력서 조회
     @GetMapping("/resume")
-    public ResponseEntity<Resource> resumeDownload(HttpServletRequest request) throws IOException {
+    public ResponseDTO resumeDownload(HttpServletRequest request) throws IOException {
         Long applicantId = Long.parseLong(jwtutil.allInOne(request.getHeader(HttpHeaders.AUTHORIZATION)).get("id"));
-        return applicantService.resumeDownload(applicantId);
+        String message = applicantService.resumeDelete(applicantId);
+        if(message == null){
+            return new ResponseDTO(401, false, "fail", "등록된 이력서가 없습니다");
+        }
+        return new ResponseDTO(200, true, message, "이력서 저장 경로");
     }
+    // 이력서 조회
+//    @GetMapping("/resume")
+//    public ResponseEntity<Resource> resumeDownload(HttpServletRequest request) throws IOException {
+//        Long applicantId = Long.parseLong(jwtutil.allInOne(request.getHeader(HttpHeaders.AUTHORIZATION)).get("id"));
+//        return applicantService.resumeDownload(applicantId);
+//    }
 
     //이력서 수정
     @PutMapping("/resume")
     public ResponseDTO resumeUpdate(MultipartFile resume, HttpServletRequest request) throws IOException {
         Long applicantId = Long.parseLong(jwtutil.allInOne(request.getHeader(HttpHeaders.AUTHORIZATION)).get("id"));
+//        Long applicantId = 1L;
         String message = applicantService.resumeSave(resume, applicantId);
         if (message.equals("empty file")) {
             return new ResponseDTO(401, true, "empty file", "빈 파일입니다.");

--- a/src/main/java/com/project/finalproject/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/project/finalproject/applicant/controller/ApplicantController.java
@@ -134,7 +134,7 @@ public class ApplicantController {
     @GetMapping("/resume")
     public ResponseDTO resumeDownload(HttpServletRequest request) throws IOException {
         Long applicantId = Long.parseLong(jwtutil.allInOne(request.getHeader(HttpHeaders.AUTHORIZATION)).get("id"));
-        String message = applicantService.resumeDelete(applicantId);
+        String message = applicantService.resumePath(applicantId);
         if(message == null){
             return new ResponseDTO(401, false, "fail", "등록된 이력서가 없습니다");
         }

--- a/src/main/java/com/project/finalproject/applicant/service/ApplicantService.java
+++ b/src/main/java/com/project/finalproject/applicant/service/ApplicantService.java
@@ -30,6 +30,7 @@ public interface ApplicantService {
 
     public String resumeSave(MultipartFile files, Long applicantId) throws IOException;
 
+    public String resumePath(Long applicantId);
     public ResponseEntity<Resource> resumeDownload(Long applicantId) throws IOException;
 
     public String resumeDelete(Long applicantId) throws IOException;

--- a/src/main/java/com/project/finalproject/applicant/service/Impl/ApplicantServiceImpl.java
+++ b/src/main/java/com/project/finalproject/applicant/service/Impl/ApplicantServiceImpl.java
@@ -177,6 +177,11 @@ public class ApplicantServiceImpl implements ApplicantService {
     }
 
     @Override
+    public String resumePath(Long applicantId){
+        Applicant applicant = applicantRepository.findById(applicantId).orElse(null);
+        return applicant.getFilePath();
+    }
+    @Override
     public ResponseEntity<Resource> resumeDownload(Long applicantId) throws IOException{ //이력서 다운로드
 
         // PDF파일을 가져온다.


### PR DESCRIPTION
## Why need this change? 
- #174 개인회원 이력서 다운로드 -> 저장경로(String) 반환

## Changes ✏️
- 

## Test checklist✅ (optional)
성공:
![image](https://user-images.githubusercontent.com/113500771/230724306-e121b34e-1a69-4c4c-bebe-e95dcf742ea0.png)

실패: 등록된 이력서가 없습니다.
![image](https://user-images.githubusercontent.com/113500771/230724332-2f9576d4-bed5-491d-9332-6c6adee2ec51.png)

