### PR TITLE
Feat:#111 일정 CRUD 기능 구현(달력)

### DIFF
--- a/src/main/java/com/project/finalproject/calendar/controller/CalendarController.java
+++ b/src/main/java/com/project/finalproject/calendar/controller/CalendarController.java
@@ -1,0 +1,52 @@
+package com.project.finalproject.calendar.controller;
+
+import com.project.finalproject.calendar.dto.CalendarReqDTO;
+import com.project.finalproject.calendar.service.CalendarService;
+import com.project.finalproject.global.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class CalendarController {
+    private final CalendarService calendarService;
+
+    /**
+     * 일정등록
+     */
+    @PostMapping("/calendar")
+    public ResponseDTO makeSchedule(@RequestBody CalendarReqDTO reqDTO, HttpServletRequest request){
+        return calendarService.makeSchedule(reqDTO, request);
+    }
+
+    /**
+     * 모든 일정 조회
+     */
+    @GetMapping("/calendar")
+    public ResponseDTO allSchedules(HttpServletRequest request){
+        return calendarService.allSchedules(request);
+    }
+
+    /**
+     * 일정수정
+     */
+    @PutMapping("/calendar/{calendarId}")
+    public ResponseDTO reviseSchedule(@PathVariable Long calendarId,
+                                      @RequestBody CalendarReqDTO reqDTO,
+                                      HttpServletRequest request){
+        return calendarService.reviseSchedule(calendarId, reqDTO, request);
+    }
+
+    /**
+     * 일정삭제
+     */
+    @DeleteMapping("/calendar/{calendarId}")
+    public ResponseDTO deleteSchedule(@PathVariable Long calendarId,
+                                      HttpServletRequest request){
+        return calendarService.deleteSchedule(calendarId, request);
+    }
+
+
+}

--- a/src/main/java/com/project/finalproject/calendar/dto/CalendarReqDTO.java
+++ b/src/main/java/com/project/finalproject/calendar/dto/CalendarReqDTO.java
@@ -1,0 +1,16 @@
+package com.project.finalproject.calendar.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CalendarReqDTO {
+
+    private String calendarTitle;
+    private String calendarContent;
+    private String calendarDate;
+
+}

--- a/src/main/java/com/project/finalproject/calendar/dto/CalendarResDTO.java
+++ b/src/main/java/com/project/finalproject/calendar/dto/CalendarResDTO.java
@@ -1,0 +1,27 @@
+package com.project.finalproject.calendar.dto;
+
+import com.project.finalproject.calendar.entity.Calendar;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CalendarResDTO {
+
+    private Long calendarId;
+    private String calendarTitle;
+    private String calendarContent;
+    private LocalDate calendarDate;
+
+    public CalendarResDTO(Calendar calendar){
+        this.calendarId = calendar.getId();
+        this.calendarTitle = calendar.getTitle();
+        this.calendarContent = calendar.getContent();
+        this.calendarDate = calendar.getDate();
+    }
+
+}

--- a/src/main/java/com/project/finalproject/calendar/entity/Calendar.java
+++ b/src/main/java/com/project/finalproject/calendar/entity/Calendar.java
@@ -1,0 +1,39 @@
+package com.project.finalproject.calendar.entity;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.company.entity.Company;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@Table(name = "tb_calendar")
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class Calendar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "calendar_id", nullable = false, unique = true)
+    private Long id; //pk
+
+    @Column(name = "calendar_title")
+    private String title;
+
+    @Column(name = "calendar_content")
+    private String content;
+
+    @Column(name = "calendar_date")
+    private LocalDate date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id")
+    private Applicant applicant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id")
+    private Company company;
+}

--- a/src/main/java/com/project/finalproject/calendar/entity/Calendar.java
+++ b/src/main/java/com/project/finalproject/calendar/entity/Calendar.java
@@ -1,7 +1,0 @@
-package com.project.finalproject.calendar.entity;
-
-/**
- * 달력
- */
-public class   Calendar {
-}

--- a/src/main/java/com/project/finalproject/calendar/repository/ApplicantCalendarRepository.java
+++ b/src/main/java/com/project/finalproject/calendar/repository/ApplicantCalendarRepository.java
@@ -1,0 +1,7 @@
+package com.project.finalproject.calendar.repository;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantCalendarRepository extends JpaRepository<Applicant, Long> {
+}

--- a/src/main/java/com/project/finalproject/calendar/repository/CalendarRepository.java
+++ b/src/main/java/com/project/finalproject/calendar/repository/CalendarRepository.java
@@ -1,0 +1,21 @@
+package com.project.finalproject.calendar.repository;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.calendar.entity.Calendar;
+import com.project.finalproject.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CalendarRepository extends JpaRepository<Calendar, Long> {
+    List<Calendar> findAllByApplicant(Applicant applicant);
+    List<Calendar> findAllByCompany(Company company);
+    Optional<Calendar> findByIdAndApplicant(Long calendarId, Applicant applicant);
+    Optional<Calendar> findByIdAndCompany(Long calendarId, Company company);
+    void deleteCalendarByIdAndApplicant(Long id, Applicant applicant);
+    void deleteCalendarByIdAndCompany(Long id, Company company);
+    Boolean existsByIdAndApplicant(Long calendarId, Applicant applicant);
+    Boolean existsByIdAndCompany(Long calendarId, Company company);
+
+}

--- a/src/main/java/com/project/finalproject/calendar/repository/CompanyCalendarRepository.java
+++ b/src/main/java/com/project/finalproject/calendar/repository/CompanyCalendarRepository.java
@@ -1,0 +1,7 @@
+package com.project.finalproject.calendar.repository;
+
+import com.project.finalproject.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyCalendarRepository extends JpaRepository<Company, Long> {
+}

--- a/src/main/java/com/project/finalproject/calendar/service/CalendarService.java
+++ b/src/main/java/com/project/finalproject/calendar/service/CalendarService.java
@@ -1,0 +1,150 @@
+package com.project.finalproject.calendar.service;
+
+import com.project.finalproject.applicant.entity.Applicant;
+import com.project.finalproject.calendar.entity.Calendar;
+import com.project.finalproject.calendar.dto.CalendarReqDTO;
+import com.project.finalproject.calendar.dto.CalendarResDTO;
+import com.project.finalproject.calendar.repository.ApplicantCalendarRepository;
+import com.project.finalproject.calendar.repository.CalendarRepository;
+import com.project.finalproject.calendar.repository.CompanyCalendarRepository;
+import com.project.finalproject.company.entity.Company;
+import com.project.finalproject.global.dto.ResponseDTO;
+import com.project.finalproject.global.exception.GlobalException;
+import com.project.finalproject.global.exception.GlobalExceptionType;
+import com.project.finalproject.global.jwt.utils.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CalendarService {
+
+    private final CalendarRepository calendarRepository;
+    private final ApplicantCalendarRepository applicantCalendarRepository;
+    private final CompanyCalendarRepository companyCalendarRepository;
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 일정등록
+     */
+    public ResponseDTO makeSchedule(CalendarReqDTO reqDTO, HttpServletRequest request){
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = jwtUtil.extractToken(authorizationHeader);
+        String role = jwtUtil.getRole(accessToken);
+        Long id = jwtUtil.getId(accessToken);
+
+        switch (role){
+            case "USER":
+                calendarRepository.save(Calendar.builder()
+                                .title(reqDTO.getCalendarTitle())
+                                .content(reqDTO.getCalendarContent())
+                                .date(LocalDate.now())
+                                .applicant(applicantCalendarRepository.findById(id).orElseThrow(()-> new GlobalException(GlobalExceptionType.NOT_FOUND)))
+                        .build());
+                return new ResponseDTO(200, true, null, "일정이 등록되었습니다.");
+            case "COMPANY":
+                calendarRepository.save(Calendar.builder()
+                        .title(reqDTO.getCalendarTitle())
+                        .content(reqDTO.getCalendarContent())
+                        .date(LocalDate.now())
+                        .company(companyCalendarRepository.findById(id).orElseThrow(()-> new GlobalException(GlobalExceptionType.NOT_FOUND)))
+                        .build());
+                return new ResponseDTO(200, true, null, "일정이 등록되었습니다.");
+            default:
+                return new ResponseDTO(404, false, null, "잘못된 접근입니다.");
+        }
+    }
+
+    /**
+     * 모든 일정 조회
+     */
+    public ResponseDTO allSchedules(HttpServletRequest request){
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = jwtUtil.extractToken(authorizationHeader);
+        String role = jwtUtil.getRole(accessToken);
+        Long id = jwtUtil.getId(accessToken);
+
+        List<CalendarResDTO> temp = new ArrayList<>();
+
+        switch (role){
+            case "USER":
+                Applicant findApplicant = applicantCalendarRepository.findById(id).orElseThrow(()-> new GlobalException(GlobalExceptionType.NOT_FOUND));
+                temp = calendarRepository.findAllByApplicant(findApplicant).stream().map(CalendarResDTO::new).collect(Collectors.toList());
+                return new ResponseDTO(200, true, temp, "모든 일정입니다.");
+            case "COMPANY":
+                Company findCompany = companyCalendarRepository.findById(id).orElseThrow(()-> new GlobalException(GlobalExceptionType.NOT_FOUND));
+                temp = calendarRepository.findAllByCompany(findCompany).stream().map(CalendarResDTO::new).collect(Collectors.toList());
+                return new ResponseDTO(200, true, temp,"모든 일정입니다.");
+            default:
+                return new ResponseDTO(404, false, null, "잘못된 접근입니다.");
+        }
+    }
+
+    /**
+     * 일정수정
+     */
+    public ResponseDTO reviseSchedule(Long calendarId, CalendarReqDTO reqDTO, HttpServletRequest request){
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = jwtUtil.extractToken(authorizationHeader);
+        String role = jwtUtil.getRole(accessToken);
+        Long id = jwtUtil.getId(accessToken);
+
+        switch (role){
+            case "USER":
+                Applicant findApplicant = applicantCalendarRepository.findById(id).orElseThrow(()->new GlobalException(GlobalExceptionType.NOT_FOUND));
+                calendarRepository.findByIdAndApplicant(calendarId, findApplicant).map(calendar -> {calendar.setTitle(reqDTO.getCalendarTitle());
+                    calendar.setContent(reqDTO.getCalendarContent());
+                    calendar.setDate(LocalDate.parse(reqDTO.getCalendarDate()));
+                    return calendarRepository.save(calendar);}).orElseThrow(()->new GlobalException(GlobalExceptionType.NOT_FOUND));
+                return new ResponseDTO(200, true, null,"일정이 수정되었습니다.");
+            case "COMPANY":
+                Company findCompany = companyCalendarRepository.findById(id).orElseThrow(()->new GlobalException(GlobalExceptionType.NOT_FOUND));
+                calendarRepository.findByIdAndCompany(calendarId, findCompany).map(calendar -> {calendar.setTitle(reqDTO.getCalendarTitle());
+                    calendar.setContent(reqDTO.getCalendarContent());
+                    calendar.setDate(LocalDate.parse(reqDTO.getCalendarDate()));
+                    return calendarRepository.save(calendar);}).orElseThrow(()->new GlobalException(GlobalExceptionType.NOT_FOUND));
+                return new ResponseDTO(200, true, null,"일정이 수정되었습니다.");
+            default:
+                return new ResponseDTO(404, true, null, "잘못된 접근입니다.");
+        }
+    }
+
+    /**
+     * 일정삭제
+     */
+    public ResponseDTO deleteSchedule(Long calendarId, HttpServletRequest request){
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String accessToken = jwtUtil.extractToken(authorizationHeader);
+        String role = jwtUtil.getRole(accessToken);
+        Long id = jwtUtil.getId(accessToken);
+
+        switch (role){
+            case "USER":
+                Applicant findApplicant = applicantCalendarRepository.findById(id).orElseThrow(()->new GlobalException(GlobalExceptionType.NOT_FOUND));
+                if(!calendarRepository.existsByIdAndApplicant(calendarId, findApplicant)){
+                    return new ResponseDTO(404, false, null, "사용자가 등록한 일정이 아닙니다.");
+                }
+                calendarRepository.deleteCalendarByIdAndApplicant(calendarId, findApplicant);
+                return new ResponseDTO(200, true, null, "일정이 삭제되었습니다.");
+            case "COMPANY":
+                Company findCompany = companyCalendarRepository.findById(id).orElseThrow(()->new GlobalException(GlobalExceptionType.NOT_FOUND));
+                if(!calendarRepository.existsByIdAndCompany(calendarId, findCompany)){
+                    return new ResponseDTO(404, false, null, "사용자가 등록한 일정이 아닙니다.");
+                }
+                calendarRepository.deleteCalendarByIdAndCompany(calendarId, findCompany);
+                return new ResponseDTO(200, true, null, "일정이 삭제되었습니다.");
+            default:
+                return new ResponseDTO(404, false, null, "잘못된 접근입니다.");
+        }
+    }
+
+}


### PR DESCRIPTION
## Why need this change? 
- 일정 CRUD 기능 구현

## Changes ✏️
- af8afb5 기존 잘못된 경로 삭제
- c728b39 Calendar 엔티티 생성
- b696a71 관련 DTO 생성
- 578301f 일정 등록, 조회, 수정, 삭제 기능 구현

## Test checklist✅ (optional)
- 일정 등록
![달력등록](https://user-images.githubusercontent.com/113500922/230736931-706a9bb8-dfec-4a8a-be12-d94967c35bc3.png)

- 사용자의 전체 일정 조회
![전체달력조회](https://user-images.githubusercontent.com/113500922/230736949-5652ac91-afc2-487d-995a-5f80721feacc.png)

- 일정 수정
![달력수정](https://user-images.githubusercontent.com/113500922/230736960-3c44f531-1529-4726-84e3-24394343b0b3.png)

- 일정 삭제
![달력삭제](https://user-images.githubusercontent.com/113500922/230736967-fbb81f25-d91e-4a4a-bab7-e01af956a854.png)

