### PR TITLE
fix : 모든 지원자 정보 불러오는 버그 수정

### DIFF
--- a/src/main/java/com/project/finalproject/company/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/project/finalproject/company/service/impl/CompanyServiceImpl.java
@@ -284,7 +284,11 @@ public class CompanyServiceImpl implements CompanyService {
 
         List<Application> application = applicationRepository.findAll();
 
-        return application.stream().map(CompanyApplicationResponse.ApplicantInfoDTO::new).collect(Collectors.toList());
+        return application
+                .stream()
+                .filter(app -> app.getJobpost().getCompany().getId().equals(company.getId()))
+                .map(CompanyApplicationResponse.ApplicantInfoDTO::new)
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
## Why need this change? 
- findall() 만하고 끝냈었음

## Changes ✏️
- 85ee62f4689dbb02b2c35827e5ab6145b2e7113c : filter 추가해서 일치하는 정보만 출력

## Test checklist✅ (optional)
- db에 company id 가 3인 사람이 쓴 글 없음 
![image](https://user-images.githubusercontent.com/51091854/230788222-ee49fb21-5c51-4f9a-b9b8-905e8a03b3e3.png)
- company id가 3인 사람이 목록 불러 왔을 때
![image](https://user-images.githubusercontent.com/51091854/230788244-0dfaa693-ac0e-47a7-b854-05a378ad726d.png)

